### PR TITLE
FIXBUG: Scope output not being populated on first run

### DIFF
--- a/nullplatform/resource_scope.go
+++ b/nullplatform/resource_scope.go
@@ -136,7 +136,7 @@ func ScopeCreate(d *schema.ResourceData, m any) error {
 	serverless_ephemeral_storage := d.Get("capabilities_serverless_ephemeral_storage").(int)
 	serverless_memory := d.Get("capabilities_serverless_memory").(int)
 
-	dimensionsMap := d.Get("dimensions").(map[string]interface{})
+	dimensionsMap := d.Get("dimensions").(map[string]any)
 	// Convert the dimensions to a map[string]string
 	dimensions := make(map[string]string)
 	for key, value := range dimensionsMap {
@@ -191,7 +191,7 @@ func ScopeCreate(d *schema.ResourceData, m any) error {
 
 	d.SetId(strconv.Itoa(s.Id))
 
-	return nil //ScopeRead(d, m)
+	return ScopeRead(d, m)
 }
 
 func patchNrnForScope(scopeNrn string, d *schema.ResourceData, m any) error {
@@ -410,7 +410,7 @@ func ScopeUpdate(d *schema.ResourceData, m any) error {
 		}
 	}
 
-	return nil //ScopeRead(d, m)
+	return ScopeRead(d, m)
 }
 
 func ScopeDelete(d *schema.ResourceData, m any) error {


### PR DESCRIPTION
When the Scope is created or updated the `Computed` values need to be refreshed. To achieve this the `ScopeRead` should be executed to fetch the values from the Null API.

The output for the first apply:
```hcl
nullplatform_scope.test: Creation complete after 0s [id=320672320]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

scope = {
  "capabilities_serverless_ephemeral_storage" = 512
  "capabilities_serverless_handler_name" = "thehandler"
  "capabilities_serverless_memory" = 512
  "capabilities_serverless_runtime_id" = "java11"
  "capabilities_serverless_timeout" = 10
  "dimensions" = tomap({
    "country" = "arg"
    "environment" = "dev"
  })
  "id" = "320672320"
  "lambda_current_function_version" = "2"
  "lambda_function_main_alias" = "DEV"
  "lambda_function_name" = "test-00"
  "lambda_function_role" = "arn:aws:iam::****:role/LambdaRole"
  "lambda_function_warm_alias" = "WARM"
  "log_group_name" = "/aws/lambda/test-00"
  "log_reader_role" = tostring(null)
  "nrn" = tostring(null)
  "null_application_id" = 12345
  "runtime_configurations" = tolist(null) /* of number */
  "s3_assets_bucket" = tostring(null)
  "scope_name" = "dev-terraform-test-01"
  "scope_type" = "serverless"
  "scope_workflow_role" = tostring(null)
}
```

After a second execution:

```hcl
Changes to Outputs:
  + nrn   = "organization=11:account=22:namespace=33:application=44:scope=320672320"
  ~ scope = {
        id                                        = "320672320"
      ~ log_reader_role                           = null -> ""
      ~ nrn                                       = null -> "organization=11:account=22:namespace=33:application=44:scope=320672320"
      ~ runtime_configurations                    = null -> [
          + 852295777,
        ]
      ~ s3_assets_bucket                          = null -> ""
      ~ scope_workflow_role                       = null -> ""
        # (15 unchanged attributes hidden)
    }
```

Expected output for the first apply:

```hcl
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

scope = {
  "capabilities_serverless_ephemeral_storage" = 512
  "capabilities_serverless_handler_name" = "thehandler"
  "capabilities_serverless_memory" = 512
  "capabilities_serverless_runtime_id" = "java11"
  "capabilities_serverless_timeout" = 10
  "dimensions" = tomap({
    "country" = "arg"
    "environment" = "dev"
  })
  "id" = "337056324"
  "lambda_current_function_version" = "2"
  "lambda_function_main_alias" = "DEV"
  "lambda_function_name" = "test-00"
  "lambda_function_role" = "arn:aws:iam::****:role/LambdaRole"
  "lambda_function_warm_alias" = "WARM"
  "log_group_name" = "/aws/lambda/test-00"
  "log_reader_role" = ""
  "nrn" = "organization="organization=11:account=22:namespace=33:application=44:scope=320672320"
  "null_application_id" = 12345
  "runtime_configurations" = tolist([
    852295777,
  ])
  "s3_assets_bucket" = ""
  "scope_name" = "dev-terraform-test-01"
  "scope_type" = "serverless"
  "scope_workflow_role" = ""
}
```

Note: Still need to update the docs and add tests.

The documentation is solved in this PR https://github.com/nullplatform/terraform-provider-nullplatform/pull/9