### PR TITLE
Update resource `nullplatform_parameter_value` to support empty values

### DIFF
--- a/nullplatform/parameter.go
+++ b/nullplatform/parameter.go
@@ -16,7 +16,7 @@ const PARAMETER_PATH = "/parameter"
 type ParameterValue struct {
 	Id            int               `json:"id,omitempty"`
 	Nrn           string            `json:"nrn,omitempty"`
-	Value         string            `json:"value,omitempty"`
+	Value         string            `json:"value"` // Can be an empty value
 	OriginVersion int               `json:"origin_version,omitempty"`
 	Dimensions    map[string]string `json:"dimensions,omitempty"`
 	CreatedAt     time.Time         `json:"created_at,omitempty"`


### PR DESCRIPTION
Como aún no está automatizada la ejecución de los acceptance tests, dejo output:

```shell
$ make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?   	github.com/nullplatform/terraform-provider-nullplatform	[no test files]
=== RUN   TestGenerateParameterValueID
--- PASS: TestGenerateParameterValueID (0.00s)
=== RUN   TestProvider_HasChildResources
--- PASS: TestProvider_HasChildResources (0.00s)
=== RUN   TestProvider_HasChildDataSources
--- PASS: TestProvider_HasChildDataSources (0.00s)
=== RUN   TestAccResourceParameter
--- PASS: TestAccResourceParameter (29.79s)
=== RUN   TestAccResourceParameterValue
--- PASS: TestAccResourceParameterValue (29.82s)
=== RUN   TestResourceScope
--- PASS: TestResourceScope (16.83s)
PASS
ok  	github.com/nullplatform/terraform-provider-nullplatform/nullplatform	77.517s
```