### PR TITLE
Update Scope to support being recreated

### DIFF
--- a/nullplatform/null_client.go
+++ b/nullplatform/null_client.go
@@ -39,6 +39,7 @@ type NullOps interface {
 	CreateScope(*Scope) (*Scope, error)
 	PatchScope(string, *Scope) error
 	GetScope(string) (*Scope, error)
+	DeleteScope(string) error
 
 	PatchNRN(string, *PatchNRN) error
 	GetNRN(string) (*NRN, error)

--- a/nullplatform/resource_scope.go
+++ b/nullplatform/resource_scope.go
@@ -255,7 +255,10 @@ func ScopeRead(d *schema.ResourceData, m any) error {
 	s, err := nullOps.GetScope(scopeID)
 
 	if err != nil {
-		d.SetId("")
+		if s.Status == "deleted" || s.Status == "deleting" {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 
@@ -437,21 +440,9 @@ func ScopeUpdate(d *schema.ResourceData, m any) error {
 
 func ScopeDelete(d *schema.ResourceData, m any) error {
 	nullOps := m.(NullOps)
+	scopeId := d.Id()
 
-	scopeID := d.Id()
-
-	pScope := &Scope{
-		Status: "deleting",
-	}
-
-	err := nullOps.PatchScope(scopeID, pScope)
-	if err != nil {
-		return err
-	}
-
-	pScope.Status = "deleted"
-
-	err = nullOps.PatchScope(scopeID, pScope)
+	err := nullOps.DeleteScope(scopeId)
 	if err != nil {
 		return err
 	}

--- a/nullplatform/scope.go
+++ b/nullplatform/scope.go
@@ -151,7 +151,7 @@ func (c *NullClient) GetScope(scopeId string) (*Scope, error) {
 	}
 
 	if s.Status == "deleted" || s.Status == "deleting" {
-		return nil, fmt.Errorf("error getting scope resource, the status is %s", s.Status)
+		return s, fmt.Errorf("error getting scope resource, the status is %s", s.Status)
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -159,4 +159,24 @@ func (c *NullClient) GetScope(scopeId string) (*Scope, error) {
 	}
 
 	return s, nil
+}
+
+func (c *NullClient) DeleteScope(scopeId string) error {
+	pScope := &Scope{
+		Status: "deleting",
+	}
+
+	err := c.PatchScope(scopeId, pScope)
+	if err != nil {
+		return err
+	}
+
+	pScope.Status = "deleted"
+
+	err = c.PatchScope(scopeId, pScope)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
When a Scope is deleted and the resource definition is still in Terraform it should recreate the Scope without receiving

```
Error: error getting scope resource, the status is deleted
```

Before:

```shell
$ make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?   	github.com/nullplatform/terraform-provider-nullplatform	[no test files]
=== RUN   TestGenerateParameterValueID
--- PASS: TestGenerateParameterValueID (0.00s)
=== RUN   TestProvider_HasChildResources
--- PASS: TestProvider_HasChildResources (0.00s)
=== RUN   TestProvider_HasChildDataSources
--- PASS: TestProvider_HasChildDataSources (0.00s)
=== RUN   TestAccResourceParameter
  error=
  | Error running pre-apply refresh: exit status 1
  |
  | Error: error getting scope resource, the status is deleted
  |
  |   with nullplatform_scope.test,
  |   on terraform_plugin_test.tf line 3, in resource "nullplatform_scope" "test":
  |    3: resource "nullplatform_scope" "test" {
  |

    resource_scope_test.go:19: Step 2/2 error: Error running pre-apply refresh: exit status 1

        Error: error getting scope resource, the status is deleted

          with nullplatform_scope.test,
          on terraform_plugin_test.tf line 3, in resource "nullplatform_scope" "test":
           3: resource "nullplatform_scope" "test" {
```

After:

```shell
$ make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?   	github.com/nullplatform/terraform-provider-nullplatform	[no test files]
=== RUN   TestGenerateParameterValueID
--- PASS: TestGenerateParameterValueID (0.00s)
=== RUN   TestProvider_HasChildResources
--- PASS: TestProvider_HasChildResources (0.00s)
=== RUN   TestProvider_HasChildDataSources
--- PASS: TestProvider_HasChildDataSources (0.00s)
=== RUN   TestAccResourceParameter
--- PASS: TestAccResourceParameter (28.09s)
=== RUN   TestAccResourceParameterValue
--- PASS: TestAccResourceParameterValue (27.83s)
=== RUN   TestResourceScope
--- PASS: TestResourceScope (21.19s)
PASS
ok  	github.com/nullplatform/terraform-provider-nullplatform/nullplatform	78.132s
```