### PR TITLE
Fix Parameter Version Hash including ParameterId

### DIFF
--- a/nullplatform/parameter.go
+++ b/nullplatform/parameter.go
@@ -269,7 +269,7 @@ func (c *NullClient) GetParameterValue(parameterId string, parameterValueId stri
 	}
 
 	for _, item := range param.Values {
-		if parameterValueId == generateParameterValueID(item) {
+		if parameterValueId == generateParameterValueID(item, param.Id) {
 			parameterValue = item
 			parameterValue.GeneratedId = parameterValueId
 			break
@@ -283,7 +283,7 @@ func (c *NullClient) GetParameterValue(parameterId string, parameterValueId stri
 	return parameterValue, nil
 }
 
-func generateParameterValueID(value *ParameterValue) string {
+func generateParameterValueID(value *ParameterValue, parameterId int) string {
 	var concatenatedString string
 
 	// Concatenate all key-value pairs from the map
@@ -292,6 +292,7 @@ func generateParameterValueID(value *ParameterValue) string {
 	}
 
 	concatenatedString += value.Nrn + ";"
+	concatenatedString += strconv.Itoa(parameterId) + ";"
 
 	// Hash the concatenated string using SHA-256
 	hash := sha256.New()

--- a/nullplatform/parameter_test.go
+++ b/nullplatform/parameter_test.go
@@ -3,18 +3,53 @@ package nullplatform
 import "testing"
 
 func TestGenerateParameterValueID(t *testing.T) {
-	// Test case 1: Dimensions is empty
+	parameterId := 1
+	// Test case 1: At Scope level without Dimensions nor Value
 	param1 := &ParameterValue{
 		Nrn: "organization=1:account=2:namespace=3:application=4:scope=5",
 	}
 
-	expectedHash1 := generateParameterValueID(param1)
-	if expectedHash1 != "045b0f80dcefa1d9cc23d79584de844611e6d99cb08674e6f1f8ebdc93bc79dd" {
-		t.Errorf("Expected hash: 045b0f80dcefa1d9cc23d79584de844611e6d99cb08674e6f1f8ebdc93bc79dd, got: %s", expectedHash1)
+	expectedHash1 := generateParameterValueID(param1, parameterId)
+	if expectedHash1 != "6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261" {
+		t.Errorf("Expected hash: 6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261, got: %s", expectedHash1)
 	}
 
-	// Test case 2: Dimensions is not empty
+	// Test case 2: At Scope level with empty Value, and without Dimensions
 	param2 := &ParameterValue{
+		Nrn:   "organization=1:account=2:namespace=3:application=4:scope=5",
+		Value: "",
+	}
+
+	expectedHash2 := generateParameterValueID(param2, parameterId)
+	if expectedHash2 != "6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261" {
+		t.Errorf("Expected hash: 6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261, got: %s", expectedHash2)
+	}
+
+	// Test case 3: At Scope level with Value, and without Dimensions
+	param3 := &ParameterValue{
+		Nrn:   "organization=1:account=2:namespace=3:application=4:scope=5",
+		Value: "_VALUE_",
+	}
+
+	expectedHash3 := generateParameterValueID(param3, parameterId)
+	if expectedHash3 != "6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261" {
+		t.Errorf("Expected hash: 6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261, got: %s", expectedHash3)
+	}
+
+	// Test case 4: At Scope level with empty Dimensions
+	param4 := &ParameterValue{
+		Nrn:        "organization=1:account=2:namespace=3:application=4:scope=5",
+		Value:      "_VALUE_",
+		Dimensions: map[string]string{},
+	}
+
+	expectedHash4 := generateParameterValueID(param4, parameterId)
+	if expectedHash4 != "6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261" {
+		t.Errorf("Expected hash: 6523e8f336a33e0da14184b31454be7df1224f64466ee090e0e28f0c41c4a261, got: %s", expectedHash4)
+	}
+
+	// Test case 5: At Application level with Dimensions nor Value
+	param5 := &ParameterValue{
 		Nrn: "organization=1:account=2:namespace=3:application=4",
 		Dimensions: map[string]string{
 			"environment": "dev",
@@ -22,8 +57,39 @@ func TestGenerateParameterValueID(t *testing.T) {
 		},
 	}
 
-	expectedHash2 := generateParameterValueID(param2)
-	if expectedHash2 != "d31e22a6e36f9c5034ca3a60bd744ad78d58fc8c37d710b2e6cf4a61efabbf1d" {
-		t.Errorf("Expected hash: d31e22a6e36f9c5034ca3a60bd744ad78d58fc8c37d710b2e6cf4a61efabbf1d, got: %s", expectedHash2)
+	expectedHash5 := generateParameterValueID(param5, parameterId)
+	if expectedHash5 != "1d6830039cf4e3143c23e3d36dd45850f7ba5241660d2ec8c5eb77dbe7c2f15d" {
+		t.Errorf("Expected hash: 1d6830039cf4e3143c23e3d36dd45850f7ba5241660d2ec8c5eb77dbe7c2f15d, got: %s", expectedHash5)
 	}
+
+	// Test case 6: At Application level with Value, and Dimensions
+	param6 := &ParameterValue{
+		Nrn:   "organization=1:account=2:namespace=3:application=4",
+		Value: "_VALUE_",
+		Dimensions: map[string]string{
+			"environment": "dev",
+			"country":     "arg",
+		},
+	}
+
+	expectedHash6 := generateParameterValueID(param6, parameterId)
+	if expectedHash6 != "1d6830039cf4e3143c23e3d36dd45850f7ba5241660d2ec8c5eb77dbe7c2f15d" {
+		t.Errorf("Expected hash: 1d6830039cf4e3143c23e3d36dd45850f7ba5241660d2ec8c5eb77dbe7c2f15d, got: %s", expectedHash6)
+	}
+
+	// Test case 7: At Scope level with Value, and Dimensions. This case shoud not exists but it can be handled
+	param7 := &ParameterValue{
+		Nrn:   "organization=1:account=2:namespace=3:application=4:scope=5",
+		Value: "_VALUE_",
+		Dimensions: map[string]string{
+			"environment": "dev",
+			"country":     "arg",
+		},
+	}
+
+	expectedHash7 := generateParameterValueID(param7, parameterId)
+	if expectedHash7 != "972d76cb3b1db5b9a145dea7aa72395ae6459f02e05ac18f7f6439904a93326f" {
+		t.Errorf("Expected hash: 972d76cb3b1db5b9a145dea7aa72395ae6459f02e05ac18f7f6439904a93326f, got: %s", expectedHash7)
+	}
+
 }

--- a/nullplatform/resource_parameter_value.go
+++ b/nullplatform/resource_parameter_value.go
@@ -2,7 +2,6 @@ package nullplatform
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"net/http"
 	"strconv"
@@ -104,7 +103,7 @@ func ParameterValueCreate(d *schema.ResourceData, m any) error {
 
 	log.Printf("[DEBUG] Parameter Value Created with OriginID: %d", paramValue.Id)
 
-	paramValueId := generateParameterValueID(paramValue)
+	paramValueId := generateParameterValueID(paramValue, parameterId)
 	d.SetId(paramValueId)
 
 	return ParameterValueRead(d, m)
@@ -194,7 +193,7 @@ func ParameterValueUpdate(d *schema.ResourceData, m any) error {
 
 		// The ID of the Parameter Value will change if other value is updated
 		// Instead the NRN and Dimensions are composed to generate an ID
-		paramValueId := generateParameterValueID(paramValue)
+		paramValueId := generateParameterValueID(paramValue, parameterId)
 		d.SetId(paramValueId)
 	}
 
@@ -221,17 +220,7 @@ func ParameterValueDelete(d *schema.ResourceData, m any) error {
 	}
 
 	for _, item := range param.Values {
-		// -------- DEBUG
-		// Convert struct to JSON
-		jsonData, err := json.Marshal(item)
-		if err != nil {
-			return err
-		}
-		// Print JSON string
-		log.Println(string(jsonData))
-		// -------- DEBUG
-
-		if parameterValueId == generateParameterValueID(item) {
+		if parameterValueId == generateParameterValueID(item, param.Id) {
 			parameterValue = item
 			break
 		}


### PR DESCRIPTION
The hash generation mechanism for identifying Parameter Value instances did not incorporate the Parameter ID. As a result, identical hash values were generated for different parameters that had the same value. This led to collisions and incorrect associations between Parameter ID and their Parameter Value.

This change will cause Terraform to re-create the values for each parameter since the hash has changed. However, other than this re-creation, there is no negative impact.

Before: same hashes
```shell
module.lambda.nullplatform_parameter_value.values["ENVIRONMENT_1"]: Creation complete after 1s [id=c22156da05cbd9cd35c8ae6e229ddef0c6cf158504fc99fd928e3b9694b8a86f]
module.lambda.nullplatform_parameter_value.values["ENVIRONMENT_2"]: Creation complete after 1s [id=c22156da05cbd9cd35c8ae6e229ddef0c6cf158504fc99fd928e3b9694b8a86f]
module.lambda.nullplatform_parameter_value.values["ENVIRONMENT_3"]: Creation complete after 0s [id=c22156da05cbd9cd35c8ae6e229ddef0c6cf158504fc99fd928e3b9694b8a86f]
module.lambda.nullplatform_parameter_value.values["EMPTY_VAR_2"]: Creation complete after 1s [id=c22156da05cbd9cd35c8ae6e229ddef0c6cf158504fc99fd928e3b9694b8a86f]
```

After: different hashes
```shell
module.lambda.nullplatform_parameter_value.values["ENVIRONMENT_1"]: Creation complete after 2s [id=69e23e4361b336dd5afaa7ae53cf0e33dc975172f8d6196c85c1d511dbb67dd2]
module.lambda.nullplatform_parameter_value.values["ENVIRONMENT_2"]: Creation complete after 1s [id=41336d186c6dd1960203673b2806636246736382a61047018b7dc90514db9ef2]
module.lambda.nullplatform_parameter_value.values["ENVIRONMENT_3"]: Creation complete after 1s [id=ed1f3b0198b57b43fc759154bfeb97125521b9da6c822322d6b79afb1d524aa1]
module.lambda.nullplatform_parameter_value.values["EMPTY_VAR_2"]: Creation complete after 0s [id=a2c3ce323cc10e69f6112f8210448a133324799d6b25efcd0e20c3029913aa2c]
```