### PR TITLE
Add ARM64 support to the Scope

### DIFF
--- a/docs/resources/parameter.md
+++ b/docs/resources/parameter.md
@@ -44,7 +44,7 @@ resource "nullplatform_parameter" "parameter" {
 ### Required
 
 - `name` (String) Definition name of the variable.
-- `nrn` (String)
+- `nrn` (String) The NRN of the application to which the parameter belongs to.
 - `variable` (String) The name of the environment variable. Required when `type = environment`.
 
 ### Optional

--- a/docs/resources/scope.md
+++ b/docs/resources/scope.md
@@ -88,6 +88,7 @@ output "scope" {
 
 - `capabilities_serverless_ephemeral_storage` (Number) The amount of Ephemeral storage (`/tmp`) to allocate for the Lambda Function in MB. This parameter is used to expand the total amount of Ephemeral storage available, beyond the default amount of `512MB`.
 - `capabilities_serverless_memory` (Number) Amount of memory in MB your Lambda Function can use at runtime. Defaults to `128`. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
+- `capabilities_serverless_runtime_platform` (String) Instruction set architecture for your Lambda function. Valid values are `x86_64`, and `arm_64`.
 - `capabilities_serverless_timeout` (Number) Amount of time your Lambda Function has to run in seconds. Defaults to `10`.
 - `dimensions` (Map of String) A key-value map with the runtime configuration dimensions that apply to this scope.
 - `lambda_function_warm_alias` (String) The Lambda function ALIAS name used to warmup the function (NRN key).

--- a/nullplatform/resource_scope_test.go
+++ b/nullplatform/resource_scope_test.go
@@ -27,6 +27,7 @@ func TestResourceScope(t *testing.T) {
 					testAccCheckResourceScopeExists("nullplatform_scope.test", &scopeID),
 					resource.TestCheckResourceAttr("nullplatform_scope.test", "scope_name", "acc-test-scope"),
 					resource.TestCheckResourceAttr("nullplatform_scope.test", "capabilities_serverless_runtime_id", "provided.al2"),
+					resource.TestCheckResourceAttr("nullplatform_scope.test", "capabilities_serverless_runtime_platform", "x86_64"),
 					resource.TestCheckResourceAttr("nullplatform_scope.test", "capabilities_serverless_handler_name", "handler"),
 					resource.TestCheckResourceAttr("nullplatform_scope.test", "capabilities_serverless_ephemeral_storage", "512"),
 					resource.TestCheckResourceAttr("nullplatform_scope.test", "log_group_name", "/aws/lambda/acc-test-lambda"),
@@ -50,6 +51,15 @@ func TestResourceScope(t *testing.T) {
 				Config: testAccScopeConfig_basic(applicationID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceScopeExists("nullplatform_scope.test", &scopeID),
+				),
+			},
+			{
+				Config: testAccScopeConfig_basicArm64(applicationID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceScopeExists("nullplatform_scope.test", &scopeID),
+					resource.TestCheckResourceAttr("nullplatform_scope.test", "scope_name", "acc-test-scope"),
+					resource.TestCheckResourceAttr("nullplatform_scope.test", "capabilities_serverless_runtime_id", "provided.al2"),
+					resource.TestCheckResourceAttr("nullplatform_scope.test", "capabilities_serverless_runtime_platform", "arm_64"),
 				),
 			},
 		},
@@ -104,6 +114,26 @@ resource "nullplatform_scope" "test" {
   null_application_id                       = %s
   scope_name                                = "acc-test-scope"
   capabilities_serverless_runtime_id        = "provided.al2"
+  capabilities_serverless_handler_name      = "handler"
+  capabilities_serverless_timeout           = 10
+  capabilities_serverless_memory            = 1024
+  capabilities_serverless_ephemeral_storage = 512
+  log_group_name                            = "/aws/lambda/acc-test-lambda"
+  lambda_function_name                      = "acc-test-lambda"
+  lambda_current_function_version           = "1"
+  lambda_function_role                      = "arn:aws:iam::123456789012:role/lambda-role"
+  lambda_function_main_alias                = "DEV"
+}
+`, applicationID)
+}
+
+func testAccScopeConfig_basicArm64(applicationID string) string {
+	return fmt.Sprintf(`
+resource "nullplatform_scope" "test" {
+  null_application_id                       = %s
+  scope_name                                = "acc-test-scope"
+  capabilities_serverless_runtime_id        = "provided.al2"
+  capabilities_serverless_runtime_platform  = "arm_64"
   capabilities_serverless_handler_name      = "handler"
   capabilities_serverless_timeout           = 10
   capabilities_serverless_memory            = 1024


### PR DESCRIPTION
* Add `capabilities_serverless_runtime_platform` attribute to `nullplatform_scope` resource
* Update documentation

```shell
$ make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?   	github.com/nullplatform/terraform-provider-nullplatform	[no test files]
=== RUN   TestGenerateParameterValueID
--- PASS: TestGenerateParameterValueID (0.00s)
=== RUN   TestProvider_HasChildResources
--- PASS: TestProvider_HasChildResources (0.00s)
=== RUN   TestProvider_HasChildDataSources
--- PASS: TestProvider_HasChildDataSources (0.00s)
=== RUN   TestAccResourceParameter
--- PASS: TestAccResourceParameter (29.84s)
=== RUN   TestAccResourceParameterValue
--- PASS: TestAccResourceParameterValue (28.92s)
=== RUN   TestResourceScope
--- PASS: TestResourceScope (23.67s)
PASS
ok  	github.com/nullplatform/terraform-provider-nullplatform/nullplatform	83.037s
```