### PR TITLE
fixes: retry create parameter if it already exists

### DIFF
--- a/nullplatform/resource_parameter_value.go
+++ b/nullplatform/resource_parameter_value.go
@@ -2,6 +2,7 @@ package nullplatform
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"strconv"
@@ -260,6 +261,13 @@ func isRetryableError(err error) bool {
 		switch httpErr.StatusCode() {
 		case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests:
 			return true
+		case http.StatusBadRequest:
+			var nErr NullErrors
+			if jsonErr := json.Unmarshal([]byte(err.Error()), &nErr); jsonErr == nil {
+				if nErr.Message == "The parameter already exists" {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/nullplatform/resource_parameter_value.go
+++ b/nullplatform/resource_parameter_value.go
@@ -102,7 +102,7 @@ func ParameterValueCreate(d *schema.ResourceData, m any) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] Parameter Value Created with OriginID: %d", paramValue.Id)
+	log.Printf("[DEBUG] Parameter Value Created with OriginID: %s", paramValue.Id)
 
 	paramValueId := generateParameterValueID(paramValue, parameterId)
 	d.SetId(paramValueId)


### PR DESCRIPTION
Although it explicity re-runs the createparameter function again, it should re-fecth parameters and find it. this is due to concurrency issues and the get of the parameter being outdated.