### PR TITLE
Lazy load the Access Token

### DIFF
--- a/nullplatform/application.go
+++ b/nullplatform/application.go
@@ -23,17 +23,9 @@ type Application struct {
 }
 
 func (c *NullClient) GetApplication(appId string) (*Application, error) {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, APPLICATION_PATH, appId)
+	path := fmt.Sprintf("%s/%s", APPLICATION_PATH, appId)
 
-	r, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/nullplatform/link.go
+++ b/nullplatform/link.go
@@ -27,24 +27,13 @@ type Link struct {
 }
 
 func (c *NullClient) CreateLink(link *Link) (*Link, error) {
-	url := fmt.Sprintf("https://%s%s", c.ApiURL, LINK_PATH)
-
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*link)
-
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := http.NewRequest("POST", url, &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("POST", LINK_PATH, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -72,24 +61,15 @@ func (c *NullClient) CreateLink(link *Link) (*Link, error) {
 }
 
 func (c *NullClient) PatchLink(linkId string, link *Link) error {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, LINK_PATH, linkId)
+	path := fmt.Sprintf("%s/%s", LINK_PATH, linkId)
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*link)
-
 	if err != nil {
 		return err
 	}
 
-	r, err := http.NewRequest("PATCH", url, &buf)
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("PATCH", path, &buf)
 	if err != nil {
 		return err
 	}
@@ -104,17 +84,9 @@ func (c *NullClient) PatchLink(linkId string, link *Link) error {
 }
 
 func (c *NullClient) DeleteLink(linkId string) error {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, LINK_PATH, linkId)
+	path := fmt.Sprintf("%s/%s", LINK_PATH, linkId)
 
-	r, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
@@ -129,17 +101,9 @@ func (c *NullClient) DeleteLink(linkId string) error {
 }
 
 func (c *NullClient) GetLink(linkId string) (*Link, error) {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, LINK_PATH, linkId)
+	path := fmt.Sprintf("%s/%s", LINK_PATH, linkId)
 
-	r, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/nullplatform/nrn.go
+++ b/nullplatform/nrn.go
@@ -53,20 +53,11 @@ type NRN struct {
 func (c *NullClient) PatchNRN(nrnId string, nrn *PatchNRN) error {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode((*nrn))
-
 	if err != nil {
 		return err
 	}
 
-	r, err := http.NewRequest("PATCH", fmt.Sprintf("https://%s%s/%s", c.ApiURL, NRN_PATH, nrnId), &buf)
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("PATCH", fmt.Sprintf("%s/%s", NRN_PATH, nrnId), &buf)
 	if err != nil {
 		return err
 	}
@@ -92,18 +83,10 @@ func (c *NullClient) GetNRN(nrnId string) (*NRN, error) {
 		jsonTag := field.Tag.Get("json")
 		namespaces = append(namespaces, jsonTag)
 	}
-	url := fmt.Sprintf("https://%s%s/%s?ids=%s", c.ApiURL, NRN_PATH, nrnId, strings.Join(namespaces, ","))
 
-	r, err := http.NewRequest("GET", url, nil)
+	path := fmt.Sprintf("%s/%s?ids=%s", NRN_PATH, nrnId, strings.Join(namespaces, ","))
 
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/nullplatform/null_client.go
+++ b/nullplatform/null_client.go
@@ -35,7 +35,6 @@ type NullErrors struct {
 }
 
 type NullOps interface {
-	//GetToken() diag.Diagnostics
 	MakeRequest(method, path string, body *bytes.Buffer) (*http.Response, error)
 
 	CreateScope(*Scope) (*Scope, error)

--- a/nullplatform/parameter.go
+++ b/nullplatform/parameter.go
@@ -48,8 +48,6 @@ type ParameterList struct {
 }
 
 func (c *NullClient) CreateParameter(param *Parameter, importIfCreated bool) (*Parameter, error) {
-	url := fmt.Sprintf("https://%s%s", c.ApiURL, PARAMETER_PATH)
-
 	parameterList, err := c.GetParameterList(param.Nrn)
 	if err != nil {
 		return nil, err
@@ -62,20 +60,11 @@ func (c *NullClient) CreateParameter(param *Parameter, importIfCreated bool) (*P
 
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(*param)
-
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(req)
+	res, err := c.MakeRequest("POST", PARAMETER_PATH, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -105,17 +94,9 @@ func (c *NullClient) CreateParameter(param *Parameter, importIfCreated bool) (*P
 }
 
 func (c *NullClient) GetParameter(parameterId string) (*Parameter, error) {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, PARAMETER_PATH, parameterId)
+	path := fmt.Sprintf("%s/%s", PARAMETER_PATH, parameterId)
 
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(req)
+	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -136,24 +117,15 @@ func (c *NullClient) GetParameter(parameterId string) (*Parameter, error) {
 }
 
 func (c *NullClient) PatchParameter(parameterId string, param *Parameter) error {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, PARAMETER_PATH, parameterId)
+	path := fmt.Sprintf("%s/%s", PARAMETER_PATH, parameterId)
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*param)
-
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("PATCH", url, &buf)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(req)
+	res, err := c.MakeRequest("PATCH", path, &buf)
 	if err != nil {
 		return err
 	}
@@ -167,17 +139,9 @@ func (c *NullClient) PatchParameter(parameterId string, param *Parameter) error 
 }
 
 func (c *NullClient) DeleteParameter(parameterId string) error {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, PARAMETER_PATH, parameterId)
+	path := fmt.Sprintf("%s/%s", PARAMETER_PATH, parameterId)
 
-	req, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(req)
+	res, err := c.MakeRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
@@ -191,24 +155,15 @@ func (c *NullClient) DeleteParameter(parameterId string) error {
 }
 
 func (c *NullClient) CreateParameterValue(paramId int, paramValue *ParameterValue) (*ParameterValue, error) {
-	url := fmt.Sprintf("https://%s%s/%s/value", c.ApiURL, PARAMETER_PATH, strconv.Itoa(paramId))
+	path := fmt.Sprintf("%s/%s/value", PARAMETER_PATH, strconv.Itoa(paramId))
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*paramValue)
-
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(req)
+	res, err := c.MakeRequest("POST", path, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -237,17 +192,9 @@ func (c *NullClient) CreateParameterValue(paramId int, paramValue *ParameterValu
 }
 
 func (c *NullClient) DeleteParameterValue(parameterId string, parameterValueId string) error {
-	url := fmt.Sprintf("https://%s%s/%s/value/%s", c.ApiURL, PARAMETER_PATH, parameterId, parameterValueId)
+	path := fmt.Sprintf("%s/%s/value/%s", PARAMETER_PATH, parameterId, parameterValueId)
 
-	req, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(req)
+	res, err := c.MakeRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
@@ -307,17 +254,9 @@ func generateParameterValueID(value *ParameterValue, parameterId int) string {
 
 func (c *NullClient) GetParameterList(nrn string) (*ParameterList, error) {
 	// TODO: Implement pagination
-	url := fmt.Sprintf("https://%s%s/?nrn=%s&limit=200", c.ApiURL, PARAMETER_PATH, nrn)
+	path := fmt.Sprintf("%s/?nrn=%s&limit=200", PARAMETER_PATH, nrn)
 
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(req)
+	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/nullplatform/provider.go
+++ b/nullplatform/provider.go
@@ -59,9 +59,7 @@ func Provider() *schema.Provider {
 			ApiURL: apiUrl,
 		}
 
-		diag := c.GetToken()
-
-		return c, diag
+		return c, nil
 	}
 
 	return provider

--- a/nullplatform/scope.go
+++ b/nullplatform/scope.go
@@ -43,8 +43,6 @@ type Scope struct {
 }
 
 func (c *NullClient) CreateScope(s *Scope) (*Scope, error) {
-	url := fmt.Sprintf("https://%s%s", c.ApiURL, SCOPE_PATH)
-
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*s)
 
@@ -52,15 +50,7 @@ func (c *NullClient) CreateScope(s *Scope) (*Scope, error) {
 		return nil, err
 	}
 
-	r, err := http.NewRequest("POST", url, &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("POST", SCOPE_PATH, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +86,7 @@ func (c *NullClient) CreateScope(s *Scope) (*Scope, error) {
 }
 
 func (c *NullClient) PatchScope(scopeId string, s *Scope) error {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, SCOPE_PATH, scopeId)
+	path := fmt.Sprintf("%s/%s", SCOPE_PATH, scopeId)
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*s)
@@ -105,15 +95,7 @@ func (c *NullClient) PatchScope(scopeId string, s *Scope) error {
 		return err
 	}
 
-	r, err := http.NewRequest("PATCH", url, &buf)
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("PATCH", path, &buf)
 	if err != nil {
 		return err
 	}
@@ -127,17 +109,9 @@ func (c *NullClient) PatchScope(scopeId string, s *Scope) error {
 }
 
 func (c *NullClient) GetScope(scopeId string) (*Scope, error) {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, SCOPE_PATH, scopeId)
+	path := fmt.Sprintf("%s/%s", SCOPE_PATH, scopeId)
 
-	r, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/nullplatform/service.go
+++ b/nullplatform/service.go
@@ -27,8 +27,6 @@ type Service struct {
 }
 
 func (c *NullClient) CreateService(s *Service) (*Service, error) {
-	url := fmt.Sprintf("https://%s%s", c.ApiURL, SERVICE_PATH)
-
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*s)
 
@@ -36,15 +34,7 @@ func (c *NullClient) CreateService(s *Service) (*Service, error) {
 		return nil, err
 	}
 
-	r, err := http.NewRequest("POST", url, &buf)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("POST", SERVICE_PATH, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +62,7 @@ func (c *NullClient) CreateService(s *Service) (*Service, error) {
 }
 
 func (c *NullClient) PatchService(serviceId string, s *Service) error {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, SERVICE_PATH, serviceId)
+	path := fmt.Sprintf("%s/%s", SERVICE_PATH, serviceId)
 
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(*s)
@@ -81,15 +71,7 @@ func (c *NullClient) PatchService(serviceId string, s *Service) error {
 		return err
 	}
 
-	r, err := http.NewRequest("PATCH", url, &buf)
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("PATCH", path, &buf)
 	if err != nil {
 		return err
 	}
@@ -104,17 +86,9 @@ func (c *NullClient) PatchService(serviceId string, s *Service) error {
 }
 
 func (c *NullClient) DeleteService(serviceId string) error {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, SERVICE_PATH, serviceId)
+	path := fmt.Sprintf("%s/%s", SERVICE_PATH, serviceId)
 
-	r, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
@@ -129,17 +103,9 @@ func (c *NullClient) DeleteService(serviceId string) error {
 }
 
 func (c *NullClient) GetService(serviceId string) (*Service, error) {
-	url := fmt.Sprintf("https://%s%s/%s", c.ApiURL, SERVICE_PATH, serviceId)
+	path := fmt.Sprintf("%s/%s", SERVICE_PATH, serviceId)
 
-	r, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
-
-	res, err := c.Client.Do(r)
+	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, the provider would fetch an access token upon definition, regardless of whether it was actually used. This change implements lazy token fetching, ensuring that an access token is only obtained when the provider is actively used (i.e., when a resource or data source is invoked). This change reduces unnecessary API calls where the provider is defined but not utilized.

### Example

Run Terraform without using any resources:
```shell
$ NP_API_KEY=DUMMY terraform apply -var 'enable=false'

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Run Terraform referencing a resource (with an invalid API Key):

```shell
$ NP_API_KEY=DUMMY terraform apply -var 'enable=true'

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # nullplatform_scope.lambda[0] will be created

nullplatform_scope.lambda[0]: Creating...
╷
│ Error: failed to get access token, got 400
│
│   with nullplatform_scope.lambda[0],
│   on main.tf line 20, in resource "nullplatform_scope" "lambda":
│   20: resource "nullplatform_scope" "lambda" {
│
╵
```

Run Terraform referencing a resource (with a valid API Key):
```shell
$ terraform apply -var 'enable=true'

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # nullplatform_scope.lambda[0] will be created
Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

nullplatform_scope.lambda[0]: Creating...
nullplatform_scope.lambda[0]: Creation complete after 3s [id=1561926553]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

**Source Code**

```hcl
terraform {
  required_providers {
    nullplatform = {
      source = "nullplatform/nullplatform"
    }
  }
}

variable "name" {
  default = "dummy-scope"
}
variable "nullplatform_application_id" {
  default = "1209140111"
}

variable "enable" {
  default = false
}

resource "nullplatform_scope" "lambda" {
  count = var.enable ? 1 : 0
  scope_name = var.name

  null_application_id = var.nullplatform_application_id

  capabilities_serverless_handler_name = "main"
  capabilities_serverless_runtime_id   = "provided.al2"
  capabilities_serverless_memory       = "128"

  lambda_function_name            = var.name
  lambda_function_role            = "arn:aws:iam::123456789012:role/${var.name}-role"
  lambda_current_function_version = "1"
  lambda_function_main_alias      = "DEV"

  log_group_name = "/aws/lambda/${var.name}"

  # Dimensions are hardcoded intentionally
  dimensions = {
    "environment" = "dev"
    "country"     = "arg"
  }
}
```