### PR TITLE
Feature: Add scope_asset_name to Scope resource

### DIFF
--- a/docs/resources/scope.md
+++ b/docs/resources/scope.md
@@ -94,6 +94,7 @@ output "scope" {
 - `lambda_function_warm_alias` (String, Deprecated) The Lambda function ALIAS name used to warmup the function (NRN key).
 - `log_reader_role` (String, Deprecated) The ARN of the IAM Role to read CloudWatch logs (NRN key).
 - `s3_assets_bucket` (String, Deprecated) The AWS S3 bucket name where the assets are stored (NRN key).
+- `scope_asset_name` (String) The asset name for the scope.
 - `scope_type` (String) Possible values: [`web_pool`, `scheduled_tasks`, `serverless`]. Defaults to `serverless`.
 - `scope_workflow_role` (String, Deprecated) The ARN of the IAM Role to deploy new versions of the Scope (NRN key).
 

--- a/nullplatform/resource_scope.go
+++ b/nullplatform/resource_scope.go
@@ -401,7 +401,7 @@ func ScopeUpdate(d *schema.ResourceData, m any) error {
 	}
 
 	if d.HasChange("scope_asset_name") {
-		ps.Type = d.Get("scope_asset_name").(string)
+		ps.AssetName = d.Get("scope_asset_name").(string)
 	}
 
 	if d.HasChange("dimensions") {

--- a/nullplatform/resource_scope.go
+++ b/nullplatform/resource_scope.go
@@ -43,6 +43,12 @@ func resourceScope() *schema.Resource {
 				Optional:    true,
 				Description: "Possible values: [`web_pool`, `scheduled_tasks`, `serverless`]. Defaults to `serverless`.",
 			},
+			"scope_asset_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The asset name for the scope.",
+			},
 			"null_application_id": {
 				Type:        schema.TypeInt,
 				Required:    true,
@@ -167,6 +173,7 @@ func ScopeCreate(d *schema.ResourceData, m any) error {
 	applicationId := d.Get("null_application_id").(int)
 	scopeName := d.Get("scope_name").(string)
 	scopeType := d.Get("scope_type").(string)
+	scopeAssetName := d.Get("scope_asset_name").(string)
 	serverless_runtime := d.Get("capabilities_serverless_runtime_id").(string)
 	serverless_platform := d.Get("capabilities_serverless_runtime_platform").(string)
 	serverless_handler := d.Get("capabilities_serverless_handler_name").(string)
@@ -185,6 +192,7 @@ func ScopeCreate(d *schema.ResourceData, m any) error {
 		Name:            scopeName,
 		ApplicationId:   applicationId,
 		Type:            scopeType,
+		AssetName:       scopeAssetName,
 		ExternalCreated: true,
 		RequestedSpec: &RequestSpec{
 			MemoryInGb:   0.5,
@@ -296,6 +304,10 @@ func ScopeRead(d *schema.ResourceData, m any) error {
 		return err
 	}
 
+	if err := d.Set("scope_asset_name", s.AssetName); err != nil {
+		return err
+	}
+
 	if err := d.Set("null_application_id", s.ApplicationId); err != nil {
 		return err
 	}
@@ -386,6 +398,10 @@ func ScopeUpdate(d *schema.ResourceData, m any) error {
 
 	if d.HasChange("scope_type") {
 		ps.Type = d.Get("scope_type").(string)
+	}
+
+	if d.HasChange("scope_asset_name") {
+		ps.Type = d.Get("scope_asset_name").(string)
 	}
 
 	if d.HasChange("dimensions") {

--- a/nullplatform/resource_scope_test.go
+++ b/nullplatform/resource_scope_test.go
@@ -62,6 +62,14 @@ func TestResourceScope(t *testing.T) {
 					resource.TestCheckResourceAttr("nullplatform_scope.test", "capabilities_serverless_runtime_platform", "arm_64"),
 				),
 			},
+			{
+				Config: testAccScopeConfig_basicWithAssetName(applicationID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceScopeExists("nullplatform_scope.test", &scopeID),
+					resource.TestCheckResourceAttr("nullplatform_scope.test", "scope_name", "acc-test-scope"),
+					resource.TestCheckResourceAttr("nullplatform_scope.test", "scope_asset_name", "the-secret-algo-lambda-asset"),
+				),
+			},
 		},
 	})
 }
@@ -134,6 +142,26 @@ resource "nullplatform_scope" "test" {
   scope_name                                = "acc-test-scope"
   capabilities_serverless_runtime_id        = "provided.al2"
   capabilities_serverless_runtime_platform  = "arm_64"
+  capabilities_serverless_handler_name      = "handler"
+  capabilities_serverless_timeout           = 10
+  capabilities_serverless_memory            = 1024
+  capabilities_serverless_ephemeral_storage = 512
+  log_group_name                            = "/aws/lambda/acc-test-lambda"
+  lambda_function_name                      = "acc-test-lambda"
+  lambda_current_function_version           = "1"
+  lambda_function_role                      = "arn:aws:iam::123456789012:role/lambda-role"
+  lambda_function_main_alias                = "DEV"
+}
+`, applicationID)
+}
+
+func testAccScopeConfig_basicWithAssetName(applicationID string) string {
+	return fmt.Sprintf(`
+resource "nullplatform_scope" "test" {
+  null_application_id                       = %s
+  scope_name                                = "acc-test-scope"
+  scope_asset_name                          = "the-secret-algo-lambda-asset"
+  capabilities_serverless_runtime_id        = "provided.al2"
   capabilities_serverless_handler_name      = "handler"
   capabilities_serverless_timeout           = 10
   capabilities_serverless_memory            = 1024

--- a/nullplatform/scope.go
+++ b/nullplatform/scope.go
@@ -36,6 +36,7 @@ type Scope struct {
 	Name                  string            `json:"name,omitempty"`
 	ApplicationId         int               `json:"application_id,omitempty"`
 	Type                  string            `json:"type,omitempty"`
+	AssetName             string            `json:"asset_name,omitempty"`
 	ExternalCreated       bool              `json:"external_created,omitempty"`
 	RequestedSpec         *RequestSpec      `json:"requested_spec,omitempty"`
 	Capabilities          *Capability       `json:"capabilities,omitempty"`


### PR DESCRIPTION
Support configuring the `asset_name` for the Scope

```shell
make testacc
TF_ACC=1 go test ./... -v  -timeout 120m
?   	github.com/nullplatform/terraform-provider-nullplatform	[no test files]
=== RUN   TestGenerateParameterValueID
--- PASS: TestGenerateParameterValueID (0.00s)
=== RUN   TestProvider_HasChildResources
--- PASS: TestProvider_HasChildResources (0.00s)
=== RUN   TestProvider_HasChildDataSources
--- PASS: TestProvider_HasChildDataSources (0.00s)
=== RUN   TestAccResourceApprovalAction
--- PASS: TestAccResourceApprovalAction (24.52s)
=== RUN   TestAccResourceApprovalPolicy
--- PASS: TestAccResourceApprovalPolicy (10.10s)
=== RUN   TestAccResourceNotificationChannel
--- PASS: TestAccResourceNotificationChannel (9.19s)
=== RUN   TestAccResourceParameter
--- PASS: TestAccResourceParameter (27.45s)
=== RUN   TestAccResourceParameterValue
--- PASS: TestAccResourceParameterValue (31.65s)
=== RUN   TestAccResourceRuntimeConfiguration
--- PASS: TestAccResourceRuntimeConfiguration (9.48s)
=== RUN   TestResourceScope
--- PASS: TestResourceScope (30.16s)
PASS
ok  	github.com/nullplatform/terraform-provider-nullplatform/nullplatform	144.016s
```