### PR TITLE
[log_requests] added logging of requests and response to null

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ build:
 release:
 	goreleaser release --rm-dist --snapshot --skip-publish  --skip-sign
 
+debug: build
+	go install .
+
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}

--- a/nullplatform/provider.go
+++ b/nullplatform/provider.go
@@ -2,11 +2,12 @@ package nullplatform
 
 import (
 	"context"
+	"log"
 	"net/http"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/motemen/go-loghttp"
 )
 
 const API_KEY = "api_key"
@@ -92,7 +93,10 @@ func Provider() *schema.Provider {
 
 		c := &NullClient{
 			Client: &http.Client{
-				Transport: &loghttp.Transport{},
+				Transport: &LoggingTransport{
+					Transport: http.DefaultTransport,
+					Logger:    log.New(os.Stdout, "HTTP: \n\n", log.Ldate|log.Ltime),
+				},
 			},
 			ApiKey: apiKey,
 			ApiURL: apiUrl,


### PR DESCRIPTION
```
 registry.opentofu.org/nullplatform/nullplatform:stdout=
  | HTTP: 
  | 
  | 2025/02/26 12:37:15 REQUEST:
  | GET /service_specification/3ec95e5f-09f5-4bbc-b047-83199ebf682d/action_specification/29bdba62-2f74-40be-98a2-c05cdba65f46 HTTP/1.1\r
  | Host: api.nullplatform.com\r
  | User-Agent: Go-http-client/1.1\r
  | Authorization: Bearer
  | Content-Type: application/json\r
  | Accept-Encoding: gzip
  
2025-02-26T12:37:15.625-0300 [TRACE] provider.stdio: waiting for stdio data
2025-02-26T12:37:15.827-0300 [TRACE] provider.stdio: received data: channel=STDOUT len=714
2025-02-26T12:37:15.827-0300 [WARN]  unexpected data:
  registry.opentofu.org/nullplatform/nullplatform:stdout=
  | HTTP: 
  | 
  | 2025/02/26 12:37:15 RESPONSE (201.45525ms):
  | HTTP/2.0 200 OK\r
  | Access-Control-Allow-Credentials: true\r
  | Access-Control-Allow-Headers: *\r
  | Access-Control-Allow-Methods: *\r
  | Access-Control-Expose-Headers: *\r
  | Content-Type: application/json; charset=utf-8\r
  | Date: Wed, 26 Feb 2025 15:37:15 GMT\r
  | Server: nginx\r
  | \r
  | {"id":"46ba9f26-1196-474c-add4-5a28498792b6","name":"update-dummy","slug":"update-dummy","type":"update","retryable":true,"service_specification_id":"3ec95e5f-09f5-4bbc-b047-83199ebf682d","link_specification_id":null,"created_at":"2025-02-26T14:33:14.031Z","updated_at":"2025-02-26T14:33:14.031Z","parameters":{"schema":{"type":"object","properties":{}},"values":{}},"results":{"schema":{},"values":{}}}
  
```