### PR TITLE
chore: bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=nullplatform
 NAMESPACE=com
 NAME=nullplatform
 BINARY=terraform-provider-${NAME}
-VERSION=0.0.48
+VERSION=0.0.53
 TEST := ./...
 
 OS := $(shell uname -o | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Description

According to our Github releases, the next version should be 0.0.53