### PR TITLE
Fixed typo in tf docs

### DIFF
--- a/docs/resources/approval_action_policy_association.md
+++ b/docs/resources/approval_action_policy_association.md
@@ -11,7 +11,7 @@ description: |-
 The `approval_action_policy_association` resource manages a **one-to-one relationship** between an approval action and a policy. It ensures that each approval action is associated with only a single policy at any given time.
 
 ~> **Ignore policies** When attaching policies using this resource, make sure to **ignore the `policies` property** in the `nullplatform_approval_action` resource. <br /><br />- Example:`lifecycle { ignore_changes = [policies] }`<br /><br />Failing to do so may result in an **infinite diff loop** and persistent plan changes during Terraform runs. For more details, see the [Terraform docs](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#ignore-changes).
-```
+
 
 ## Example Usage
 


### PR DESCRIPTION
Fixing typo that broke the example codeblock

![image](https://github.com/user-attachments/assets/a9c73baf-18c7-44b8-8a0d-f381f8e87f0a)
