### PR TITLE
feat(description): add optional description field to scope, service_specification and action_specification resources

### DIFF
--- a/nullplatform/action_specification.go
+++ b/nullplatform/action_specification.go
@@ -11,6 +11,7 @@ import (
 type ActionSpecification struct {
 	Id                     string                 `json:"id,omitempty"`
 	Name                   string                 `json:"name,omitempty"`
+	Description            string                 `json:"description,omitempty"`
 	Type                   string                 `json:"type,omitempty"`
 	Parameters             map[string]interface{} `json:"parameters,omitempty"`
 	Results                map[string]interface{} `json:"results,omitempty"`

--- a/nullplatform/resource_action_specification.go
+++ b/nullplatform/resource_action_specification.go
@@ -32,6 +32,11 @@ func resourceActionSpecification() *schema.Resource {
 				Required:    true,
 				Description: "Name of the action specification",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of the action specification",
+			},
 			"slug": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -110,6 +115,7 @@ func ActionSpecificationCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	spec := &ActionSpecification{
 		Name:                   d.Get("name").(string),
+		Description:            d.Get("description").(string),
 		Type:                   d.Get("type").(string),
 		Parameters:             parameters,
 		Results:                results,
@@ -157,6 +163,9 @@ func ActionSpecificationRead(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	if err := d.Set("name", spec.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", spec.Description); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("slug", spec.Slug); err != nil {
@@ -227,6 +236,10 @@ func ActionSpecificationUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	if d.HasChange("name") {
 		spec.Name = d.Get("name").(string)
+	}
+
+	if d.HasChange("description") {
+		spec.Description = d.Get("description").(string)
 	}
 
 	if d.HasChange("type") {

--- a/nullplatform/resource_service_specification.go
+++ b/nullplatform/resource_service_specification.go
@@ -31,6 +31,11 @@ func resourceServiceSpecification() *schema.Resource {
 				Required:    true,
 				Description: "Name of the service specification",
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of the service specification",
+			},
 			"slug": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -167,6 +172,7 @@ func CreateServiceSpecification(_ context.Context, d *schema.ResourceData, m int
 
 	spec := &ServiceSpecification{
 		Name:              d.Get("name").(string),
+		Description:       d.Get("description").(string),
 		VisibleTo:         visibleTo,
 		Dimensions:        dimensions,
 		AssignableTo:      d.Get("assignable_to").(string),
@@ -196,6 +202,9 @@ func ReadServiceSpecification(_ context.Context, d *schema.ResourceData, m inter
 	}
 
 	if err := d.Set("name", spec.Name); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("description", spec.Description); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("slug", spec.Slug); err != nil {
@@ -262,6 +271,10 @@ func UpdateServiceSpecification(ctx context.Context, d *schema.ResourceData, m i
 
 	if d.HasChange("name") {
 		spec.Name = d.Get("name").(string)
+	}
+
+	if d.HasChange("description") {
+		spec.Description = d.Get("description").(string)
 	}
 
 	if d.HasChange("visible_to") {

--- a/nullplatform/service_specification.go
+++ b/nullplatform/service_specification.go
@@ -22,6 +22,7 @@ type Selectors struct {
 type ServiceSpecification struct {
 	Id                string                 `json:"id,omitempty"`
 	Name              string                 `json:"name,omitempty"`
+	Description       string                 `json:"description,omitempty"`
 	Slug              string                 `json:"slug,omitempty"`
 	VisibleTo         []string               `json:"visible_to,omitempty"`
 	Dimensions        map[string]interface{} `json:"dimensions,omitempty"`


### PR DESCRIPTION
## Summary
- Add optional `description` field to `nullplatform_scope` resource
- Add optional `description` field to `nullplatform_service_specification` resource
- Add optional `description` field to `nullplatform_action_specification` resource

## Changes
- Updated Go structs with `json:"description,omitempty"` tag
- Added `description` to Terraform schema as `Optional`
- Handled `description` in Create, Read, and Update functions for each resource

## Notes
- Pattern follows existing `description` implementation in `nullplatform_metadata_specification` and `nullplatform_provider_specification`
- `nullplatform_scope_type` already had `description` as Required — not modified