### PR TITLE
feat(provider_config): make dimensions optional

### DIFF
--- a/nullplatform/provider_config.go
+++ b/nullplatform/provider_config.go
@@ -16,7 +16,7 @@ const (
 type ProviderConfig struct {
 	Id              string                 `json:"id,omitempty"`
 	Nrn             string                 `json:"nrn,omitempty"`
-	Dimensions      map[string]string      `json:"dimensions"`
+	Dimensions      map[string]string      `json:"dimensions,omitempty"`
 	SpecificationId string                 `json:"specification_id,omitempty"`
 	Attributes      map[string]interface{} `json:"attributes,omitempty"`
 }

--- a/nullplatform/resource_provider_config.go
+++ b/nullplatform/resource_provider_config.go
@@ -29,11 +29,11 @@ func resourceProviderConfig() *schema.Resource {
 			"dimensions": {
 				Type:     schema.TypeMap,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Description: "A key-value map with the provider dimensions that apply to this scope.",
+				Description: "A key-value map with the provider dimensions that apply to this scope. Optional: when omitted, the provider config applies without dimension scoping.",
 			},
 			"type": {
 				Type:        schema.TypeString,
@@ -76,10 +76,13 @@ func ProviderConfigCreate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	dimensionsMap := d.Get("dimensions").(map[string]interface{})
-	dimensions := make(map[string]string)
-	for key, value := range dimensionsMap {
-		dimensions[key] = value.(string)
+	var dimensions map[string]string
+	if v, ok := d.GetOk("dimensions"); ok {
+		dimensionsMap := v.(map[string]interface{})
+		dimensions = make(map[string]string, len(dimensionsMap))
+		for key, value := range dimensionsMap {
+			dimensions[key] = value.(string)
+		}
 	}
 
 	attributesJSON := d.Get("attributes").(string)


### PR DESCRIPTION
## Summary

- Change `dimensions` from `Required` to `Optional` in the `nullplatform_provider_config` schema.
- Tag the `Dimensions` field with `json:",omitempty"` and only allocate the map when the user provided values, so when omitted the field is **not serialized in the wire body** (instead of being sent as `null` or an empty map).

## Motivation

Provider types whose specification has `allow_dimensions: false` (e.g. `ecr`) currently force users to write `dimensions = {}` as a no-op placeholder. With this change the field can simply be omitted from the HCL.

## Backward compatibility

- Configs that pass populated dimensions: unchanged behavior, dimensions are sent as before.
- Configs that pass `dimensions = {}`: still work; the empty map flows through.
- Configs that omit `dimensions`: previously rejected at plan time with `argument is required`; now planned and applied successfully.

## Test plan

Verified end-to-end against `api.nullplatform.com` using a local `dev_overrides` build of this branch:

- [x] `tofu plan` accepts a `nullplatform_provider_config` resource without the `dimensions` argument (no `argument is required` error).
- [x] `tofu apply` succeeds against `type = "ecr"` (which has `allow_dimensions: false`) with no `dimensions` in the HCL. Captured DEBUG log confirms the POST body is `{"nrn":"...","specification_id":"...","attributes":{...}}` — **no `dimensions` key in the request**.
- [x] `tofu apply` against a type with `allow_dimensions: true` (`aws-configuration`) with populated `dimensions = { environment = "..." }` still serializes them correctly: POST body is `{"nrn":"...","dimensions":{"environment":"..."},"specification_id":"...","attributes":{...}}`. The field reaches the backend exactly as before.
- [x] `tofu destroy` cleans up the created provider config.
- [x] `go build ./...` and `go vet ./...` pass.