### PR TITLE
feat(client): retry transient failures on GET requests

### DIFF
--- a/nullplatform/errors.go
+++ b/nullplatform/errors.go
@@ -14,6 +14,19 @@ func (e *ApiError) Error() string {
 	return fmt.Sprintf("%d: %s", e.ID, e.Message)
 }
 
+type HTTPStatusError struct {
+	Status  int
+	Message string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("status code: %d, message: %s", e.Status, e.Message)
+}
+
+func (e *HTTPStatusError) StatusCode() int {
+	return e.Status
+}
+
 type ResourceExistsError struct {
 	ApiType string
 	ID      int

--- a/nullplatform/null_client.go
+++ b/nullplatform/null_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -17,6 +18,24 @@ import (
 )
 
 const TOKEN_PATH = "/token"
+
+const (
+	defaultGetMaxRetries = 3
+	defaultGetRetryDelay = 100 * time.Millisecond
+)
+
+func isRetryableStatusCode(statusCode int) bool {
+	switch statusCode {
+	case http.StatusRequestTimeout,
+		http.StatusConflict,
+		http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	}
+	return false
+}
 
 type TokenRequest struct {
 	Apikey string `json:"apikey"`
@@ -275,7 +294,31 @@ func (c *NullClient) MakeRequest(method, path string, body *bytes.Buffer) (*http
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token.AccessToken))
 
-	return c.Client.Do(req)
+	if method != http.MethodGet {
+		return c.Client.Do(req)
+	}
+
+	var res *http.Response
+	for attempt := 0; attempt <= defaultGetMaxRetries; attempt++ {
+		res, err = c.Client.Do(req)
+		if err == nil && !isRetryableStatusCode(res.StatusCode) {
+			return res, nil
+		}
+
+		if attempt == defaultGetMaxRetries {
+			break
+		}
+
+		if res != nil {
+			io.Copy(io.Discard, res.Body)
+			res.Body.Close()
+		}
+
+		log.Printf("[WARN] GET %s retry %d/%d after error/status (err=%v)", path, attempt+1, defaultGetMaxRetries, err)
+		time.Sleep(defaultGetRetryDelay)
+	}
+
+	return res, err
 }
 
 func (c *NullClient) ensureValidToken() error {

--- a/nullplatform/null_client_test.go
+++ b/nullplatform/null_client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -81,6 +82,96 @@ func TestMakeRequest_ContentTypeOnlySetWhenBodyPresent(t *testing.T) {
 			if hasContentType != tt.wantContentType {
 				t.Errorf("Content-Type header present=%v, want present=%v (got %q)",
 					hasContentType, tt.wantContentType, capturedContentType)
+			}
+		})
+	}
+}
+
+func TestMakeRequest_RetryOnGet(t *testing.T) {
+	tests := []struct {
+		name             string
+		method           string
+		failuresBefore2xx int32
+		respondStatus    int
+		wantAttempts     int32
+		wantStatus       int
+	}{
+		{
+			name:             "GET retries on 503 until success",
+			method:           "GET",
+			failuresBefore2xx: 2,
+			respondStatus:    http.StatusServiceUnavailable,
+			wantAttempts:     3,
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "GET stops after max retries",
+			method:           "GET",
+			failuresBefore2xx: 10,
+			respondStatus:    http.StatusBadGateway,
+			wantAttempts:     4,
+			wantStatus:       http.StatusBadGateway,
+		},
+		{
+			name:             "GET does not retry on 200",
+			method:           "GET",
+			failuresBefore2xx: 0,
+			respondStatus:    http.StatusOK,
+			wantAttempts:     1,
+			wantStatus:       http.StatusOK,
+		},
+		{
+			name:             "GET does not retry on 404",
+			method:           "GET",
+			failuresBefore2xx: 10,
+			respondStatus:    http.StatusNotFound,
+			wantAttempts:     1,
+			wantStatus:       http.StatusNotFound,
+		},
+		{
+			name:             "DELETE never retries on 503",
+			method:           "DELETE",
+			failuresBefore2xx: 10,
+			respondStatus:    http.StatusServiceUnavailable,
+			wantAttempts:     1,
+			wantStatus:       http.StatusServiceUnavailable,
+		},
+		{
+			name:             "POST never retries on 502",
+			method:           "POST",
+			failuresBefore2xx: 10,
+			respondStatus:    http.StatusBadGateway,
+			wantAttempts:     1,
+			wantStatus:       http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int32
+
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				n := atomic.AddInt32(&attempts, 1)
+				if n <= tt.failuresBefore2xx {
+					w.WriteHeader(tt.respondStatus)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			client := newTestClient(server)
+			res, err := client.MakeRequest(tt.method, "/test", nil)
+			if err != nil {
+				t.Fatalf("MakeRequest returned unexpected error: %v", err)
+			}
+			defer res.Body.Close()
+
+			if got := atomic.LoadInt32(&attempts); got != tt.wantAttempts {
+				t.Errorf("attempts = %d, want %d", got, tt.wantAttempts)
+			}
+			if res.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", res.StatusCode, tt.wantStatus)
 			}
 		})
 	}

--- a/nullplatform/parameter.go
+++ b/nullplatform/parameter.go
@@ -101,15 +101,15 @@ func (c *NullClient) GetParameter(parameterId string, nrn *string) (*Parameter, 
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return nil, &HTTPStatusError{Status: res.StatusCode, Message: fmt.Sprintf("error getting Parameter resource for %s", parameterId)}
+	}
+
 	param := &Parameter{}
 	derr := json.NewDecoder(res.Body).Decode(param)
 
 	if derr != nil {
 		return nil, derr
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error getting Parameter resource, got %d for %s", res.StatusCode, parameterId)
 	}
 
 	return param, nil
@@ -170,14 +170,14 @@ func (c *NullClient) CreateParameterValue(paramId int, paramValue *ParameterValu
 
 	if res.StatusCode != http.StatusOK {
 		if res.StatusCode == http.StatusGatewayTimeout {
-			return nil, fmt.Errorf("error creating Parameter Value, status code: %d, message: Gateway Timeout", res.StatusCode)
+			return nil, &HTTPStatusError{Status: res.StatusCode, Message: "error creating Parameter Value: Gateway Timeout"}
 		}
 
 		nErr := &NullErrors{}
 		if dErr := json.NewDecoder(res.Body).Decode(nErr); dErr != nil {
-			return nil, fmt.Errorf("error creating Parameter Value, status code: %d, message: %w", res.StatusCode, dErr)
+			return nil, &HTTPStatusError{Status: res.StatusCode, Message: fmt.Sprintf("error creating Parameter Value: %s", dErr)}
 		}
-		return nil, fmt.Errorf("error creating Parameter Value, status code: %d, message: %s", res.StatusCode, nErr.Message)
+		return nil, &HTTPStatusError{Status: res.StatusCode, Message: fmt.Sprintf("error creating Parameter Value: %s", nErr.Message)}
 	}
 
 	paramRes := &ParameterValue{}
@@ -200,7 +200,7 @@ func (c *NullClient) DeleteParameterValue(parameterId string, parameterValueId s
 	defer res.Body.Close()
 
 	if (res.StatusCode != http.StatusOK) && (res.StatusCode != http.StatusNoContent) {
-		return fmt.Errorf("error deleting Parameter resource, got %d", res.StatusCode)
+		return &HTTPStatusError{Status: res.StatusCode, Message: "error deleting Parameter Value"}
 	}
 
 	return nil
@@ -211,7 +211,7 @@ func (c *NullClient) GetParameterValue(parameterId string, parameterValueId stri
 
 	param, err := c.GetParameter(parameterId, nrn)
 	if err != nil {
-		return nil, fmt.Errorf("Parameter ID %s not found", parameterId)
+		return nil, fmt.Errorf("Parameter ID %s not found: %w", parameterId, err)
 	}
 
 	for _, item := range param.Values {

--- a/nullplatform/parameter_test.go
+++ b/nullplatform/parameter_test.go
@@ -1,6 +1,11 @@
 package nullplatform
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
 
 func TestGenerateParameterValueID(t *testing.T) {
 	parameterId := 1
@@ -90,5 +95,35 @@ func TestGenerateParameterValueID(t *testing.T) {
 	expectedHash7 := generateParameterValueID(param7, parameterId)
 	if expectedHash7 != "972d76cb3b1db5b9a145dea7aa72395ae6459f02e05ac18f7f6439904a93326f" {
 		t.Errorf("Expected hash: 972d76cb3b1db5b9a145dea7aa72395ae6459f02e05ac18f7f6439904a93326f, got: %s", expectedHash7)
+	}
+}
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"408 timeout", &HTTPStatusError{Status: http.StatusRequestTimeout, Message: "x"}, true},
+		{"409 conflict", &HTTPStatusError{Status: http.StatusConflict, Message: "x"}, true},
+		{"429 too many", &HTTPStatusError{Status: http.StatusTooManyRequests, Message: "x"}, true},
+		{"502 bad gateway", &HTTPStatusError{Status: http.StatusBadGateway, Message: "x"}, true},
+		{"503 unavailable", &HTTPStatusError{Status: http.StatusServiceUnavailable, Message: "x"}, true},
+		{"504 gateway timeout", &HTTPStatusError{Status: http.StatusGatewayTimeout, Message: "x"}, true},
+		{"400 already exists", &HTTPStatusError{Status: http.StatusBadRequest, Message: "The parameter already exists"}, true},
+		{"400 other", &HTTPStatusError{Status: http.StatusBadRequest, Message: "invalid input"}, false},
+		{"404 not found", &HTTPStatusError{Status: http.StatusNotFound, Message: "x"}, false},
+		{"500 internal", &HTTPStatusError{Status: http.StatusInternalServerError, Message: "x"}, false},
+		{"wrapped 503", fmt.Errorf("context: %w", &HTTPStatusError{Status: http.StatusServiceUnavailable, Message: "x"}), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableError(tt.err); got != tt.want {
+				t.Errorf("isRetryableError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }

--- a/nullplatform/resource_parameter_value.go
+++ b/nullplatform/resource_parameter_value.go
@@ -2,10 +2,11 @@ package nullplatform
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -257,18 +258,20 @@ func ParameterValueDelete(d *schema.ResourceData, m any) error {
 }
 
 func isRetryableError(err error) bool {
-	if httpErr, ok := err.(interface{ StatusCode() int }); ok {
-		switch httpErr.StatusCode() {
-		case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests, http.StatusServiceUnavailable, http.StatusGatewayTimeout, http.StatusBadGateway:
-			return true
-		case http.StatusBadRequest:
-			var nErr NullErrors
-			if jsonErr := json.Unmarshal([]byte(err.Error()), &nErr); jsonErr == nil {
-				if nErr.Message == "The parameter already exists" {
-					return true
-				}
-			}
-		}
+	var httpErr *HTTPStatusError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	switch httpErr.StatusCode() {
+	case http.StatusRequestTimeout,
+		http.StatusConflict,
+		http.StatusTooManyRequests,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		http.StatusBadGateway:
+		return true
+	case http.StatusBadRequest:
+		return strings.Contains(httpErr.Message, "already exists")
 	}
 	return false
 }


### PR DESCRIPTION
Retry GET requests up to 3 times with 100ms backoff on transient errors (408, 409, 429, 502, 503, 504) and network failures. Only GETs retry — they're idempotent so it's safe; mutating verbs pass through unchanged.