### PR TITLE
feat(account): read soft-deleted accounts via show_deleted=true

### DIFF
--- a/nullplatform/account.go
+++ b/nullplatform/account.go
@@ -81,7 +81,11 @@ func (c *NullClient) PatchAccount(accountId string, account *Account) error {
 }
 
 func (c *NullClient) GetAccount(accountId string) (*Account, error) {
-	path := fmt.Sprintf("%s/%s", ACCOUNT_PATH, accountId)
+	// Always request soft-deleted rows so Terraform can reconcile state when an
+	// account has been deleted out-of-band. The API responds 200 with status="deleted"
+	// (instead of 404) when show_deleted=true; the resource layer treats that the
+	// same as "inactive" and drops the resource from state.
+	path := fmt.Sprintf("%s/%s?show_deleted=true", ACCOUNT_PATH, accountId)
 
 	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {

--- a/nullplatform/resource_account.go
+++ b/nullplatform/resource_account.go
@@ -118,7 +118,7 @@ func AccountRead(d *schema.ResourceData, m any) error {
 
 	account, err := nullOps.GetAccount(accountId)
 	if err != nil {
-		if account.Status == "inactive" {
+		if account != nil && (account.Status == "inactive" || account.Status == "deleted") {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
## Summary

Hardcodes `?show_deleted=true` on `GetAccount` so the provider can read tombstoned accounts and reconcile Terraform state when an account has been deleted out-of-band. The companion API change (nullplatform/main-core-entities-api#591) returns the row with `status="deleted"` in that case; this PR extends the `AccountRead` state-removal check at `resource_account.go:121` to treat `"deleted"` the same as `"inactive"` (drop from state, return nil).

Before this PR, a `terraform plan` against a deleted account would fail with a 404 from the API; after this PR, the resource is silently removed from state, matching the existing behavior for inactive accounts.

Companion PRs:
- API: nullplatform/main-core-entities-api#591 (paranoid bypass + status override)
- docsite: nullplatform/docsite#680 (OpenAPI spec)
- CLI: nullplatform/cli#180 (CLI spec)

## Design notes

- **Flag is hardcoded, not exposed as a resource attribute.** Soft-deleted reads are an internal reconciliation concern; surfacing the flag to Terraform users adds no value.
- **Defensive `account != nil` guard added** at `resource_account.go:121`. Previously the code dereferenced `account.Status` even when `err != nil`, which can be nil from `GetAccount` (JSON decode error or non-2xx without `status="deleted"`). The new guard prevents a panic in those edge cases.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] Existing unit tests pass (one pre-existing unrelated failure on `TestProvider_HasChildDataSources` that already fails on main)
- [ ] Manual integration test: create an account via Terraform, delete it out-of-band via API, run `terraform plan` — should report the resource as removed and offer to recreate.