### PR TITLE
fix(provider_config): use PATCH instead of PUT for updates

### DIFF
--- a/nullplatform/provider_config.go
+++ b/nullplatform/provider_config.go
@@ -84,7 +84,7 @@ func (c *NullClient) PatchProviderConfig(providerConfigId string, p *ProviderCon
 }
 
 func (c *NullClient) GetProviderConfig(providerConfigId string) (*ProviderConfig, error) {
-	path := fmt.Sprintf("%s/%s", PROVIDER_CONFIG_PATH, providerConfigId)
+	path := fmt.Sprintf("%s/%s?no_merge=true", PROVIDER_CONFIG_PATH, providerConfigId)
 
 	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {

--- a/nullplatform/provider_config.go
+++ b/nullplatform/provider_config.go
@@ -69,7 +69,7 @@ func (c *NullClient) PatchProviderConfig(providerConfigId string, p *ProviderCon
 		return fmt.Errorf("failed to encode provider config: %v", err)
 	}
 
-	res, err := c.MakeRequest("PUT", path, &buf)
+	res, err := c.MakeRequest("PATCH", path, &buf)
 	if err != nil {
 		return fmt.Errorf("failed to make API request: %v", err)
 	}
@@ -84,7 +84,7 @@ func (c *NullClient) PatchProviderConfig(providerConfigId string, p *ProviderCon
 }
 
 func (c *NullClient) GetProviderConfig(providerConfigId string) (*ProviderConfig, error) {
-	path := fmt.Sprintf("%s/%s?no_merge=true", PROVIDER_CONFIG_PATH, providerConfigId)
+	path := fmt.Sprintf("%s/%s", PROVIDER_CONFIG_PATH, providerConfigId)
 
 	res, err := c.MakeRequest("GET", path, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes the `500 FST_ERR_RUNTIME_CONFIGURATION` error returned when running `tofu apply` with changes on any `nullplatform_provider_config` that has `dimensions != {}` (regardless of the spec: `azure-configuration`, `aws-configuration`, etc.).

## Changes

One single behavior change: `PatchProviderConfig` now sends `PATCH` instead of `PUT` to the `/provider/:id` endpoint.

```diff
-    res, err := c.MakeRequest("PUT", path, &buf)
+    res, err := c.MakeRequest("PATCH", path, &buf)
```

`PUT` on the providers API is a full replace and goes through a backend code path that fails for dimensional configs. `PATCH` does a partial merge and works correctly.

## Why only this hunk

The original version of this branch (commit `41dd133` by @sebas_correa) also removed the `?no_merge=true` query param from `GetProviderConfig`. We empirically validated that this second change introduced a different problem: **perpetual drift from attribute inheritance** in the NRN hierarchy.

Without `no_merge=true`:
- The GET returns attributes merged from the parent hierarchy
- `main.tf` typically declares only a subset (what this specific provider sets)
- TF detects diff between the declared subset and the merged response → drift on every plan
- Every `tofu apply` sends a harmless but noisy PATCH, even if the config did not change
- Existing `nullplatform/tofu-modules` deployments in production start showing drift without any user-side change