### PR TITLE
fix(release): drop unsupported windows/arm build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,9 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    # 32-bit windows/arm port was removed in Go 1.26; Windows on ARM uses arm64
+    - goos: windows
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
## What

Go 1.26 removed the 32-bit `windows/arm` port. After #130 bumped the build toolchain to `go1.26.4`, the `v0.0.94` release failed in goreleaser:

```
failed to build for windows_arm_6: go: unsupported GOOS/GOARCH pair windows/arm
```

This excludes `windows/arm` from the build matrix, mirroring the existing `darwin/386` ignore.

## Why it's safe

In the failed `v0.0.94` run, every other target built successfully with `go1.26.4` — including `windows/arm64`, the actual Windows-on-ARM target. Only the legacy 32-bit `windows/arm` pair is no longer a valid Go port, so dropping it loses nothing.

## After merge

Re-tag/re-release (e.g. `v0.0.95`) to publish a complete artifact set.
