### PR TITLE
ci: auto-generate provider docs on pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,16 +11,19 @@ name: docs
 
 on:
   pull_request:
+    # Only the paths that actually affect generated docs: the provider schema
+    # (Go source), the examples embedded into docs, and the doc templates.
+    # (go.mod/go.sum dependency bumps don't change docs, so they're excluded.)
     paths:
       - "nullplatform/**"
       - "examples/**"
       - "templates/**"
       - "docs/**"
-      - "go.mod"
-      - "go.sum"
-      - "main.go"
-      - "tools/**"
   workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -28,15 +31,15 @@ permissions:
 jobs:
   update:
     name: regenerate docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "go.mod"
           cache: true
@@ -44,7 +47,7 @@ jobs:
       # tfplugindocs shells out to `terraform` to format examples and read the
       # provider schema, so terraform must be on PATH.
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,84 @@
+# Keeps the generated documentation under docs/ in sync with the provider
+# schema and the examples. On every pull request it regenerates the docs the
+# same way a developer does locally (`make update-docs` / `go generate ./...`)
+# and, if anything changed, commits the result back to the PR branch — so
+# contributors never have to remember to regenerate docs by hand.
+#
+# Pull requests from forks cannot be pushed to with the default token, so in
+# that case (and for manual runs) the job fails instead and asks you to run
+# `make update-docs` locally.
+name: docs
+
+on:
+  pull_request:
+    paths:
+      - "nullplatform/**"
+      - "examples/**"
+      - "templates/**"
+      - "docs/**"
+      - "go.mod"
+      - "go.sum"
+      - "main.go"
+      - "tools/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    name: regenerate docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      # tfplugindocs shells out to `terraform` to format examples and read the
+      # provider schema, so terraform must be on PATH.
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
+      # Runs the //go:generate directives in main.go:
+      #   - terraform fmt -recursive ./examples/
+      #   - tfplugindocs generate   (pinned to the version in go.mod via tools/)
+      - name: Regenerate docs
+        run: go generate ./...
+
+      - name: Detect changes
+        id: diff
+        run: |
+          git add -A docs/ examples/
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Same-repo PR: commit the regenerated docs back to the contributor's branch.
+      - name: Commit regenerated docs
+        if: ${{ steps.diff.outputs.changed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "docs: regenerate from schema and examples"
+          git push origin "HEAD:$BRANCH"
+
+      # Fork PR or manual run: cannot push, so fail and point to the local command.
+      - name: Fail if out of date (fork PR or manual run)
+        if: ${{ steps.diff.outputs.changed == 'true' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+        run: |
+          echo "::error::Generated docs/examples are out of date and this run cannot push (fork PR or manual run). Run 'make update-docs' (or 'go generate ./...') locally and commit the result."
+          git diff --cached
+          exit 1

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ After that, you can run the following command to autogenerate the documentation 
 make update-docs
 ```
 
+> **CI:** the `docs` GitHub Action regenerates the docs on every pull request and
+> commits them back to your branch automatically, so you don't have to run
+> `make update-docs` by hand. (For pull requests from forks it can't push, so the
+> job fails and you should run `make update-docs` locally and commit.)
+
 ### Publishing a Release
 
 To publish a new release of the provider:


### PR DESCRIPTION
Adds `.github/workflows/docs.yml`: on every PR touching schema/examples/templates/docs, regenerates the docs (`go generate ./...` = `terraform fmt` + `tfplugindocs`, pinned via `tools/`) and **commits them back to the PR branch** — so contributors never regenerate docs by hand.

- Token: default `GITHUB_TOKEN` (`contents: write`). Fork PRs can't be pushed → the job fails with a hint to run `make update-docs`.
- Verified: YAML valid, all action SHAs pinned to real tags, injection-safe (no `${{ }}` inside `run:`).
- Does not touch `docs/`/`examples/` → zero conflict with other open PRs.

**Merge this first** — it must be on `main` for the examples PR to auto-generate docs.