### PR TITLE
docs(provider): bump install example version to ~> 0.0.96

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nullplatform = {
       source  = "nullplatform/nullplatform"
-      version = "~> 0.0.14"
+      version = "~> 0.0.96"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ terraform {
   required_providers {
     nullplatform = {
       source  = "nullplatform/nullplatform"
-      version = "~> 0.0.96"
+      version = "~> 0.0.98"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nullplatform = {
       source  = "nullplatform/nullplatform"
-      version = "~> 0.0.14"
+      version = "~> 0.0.96"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nullplatform = {
       source  = "nullplatform/nullplatform"
-      version = "~> 0.0.96"
+      version = "~> 0.0.98"
     }
   }
 }


### PR DESCRIPTION
El snippet 'Example Usage' del index del provider pineaba `~> 0.0.14` (obsoleto). Lo subo a la versión actual.

- Toca solo la **fuente**: `examples/provider/provider.tf` (1 línea).
- `docs/index.md` lo **regenera el workflow de docs** en este PR (no se edita a mano).
- Entra en la próxima release → `latest/docs` muestra la versión correcta.