### PR TITLE
ci(dependabot): add gomod and github-actions update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+updates:
+  # Go modules: security updates only (open-pull-requests-limit: 0 disables
+  # routine version bumps; Dependabot security/CVE PRs still flow regardless).
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    groups:
+      gomod:
+        patterns:
+          - "*"
+
+  # GitHub Actions: version updates enabled so action versions (uses:) stay
+  # current; also covers security advisories on actions.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Qué

Agrega configuración de Dependabot (`.github/dependabot.yml`) para este provider de Terraform.

## Cómo

- **`gomod`** (`directory: /`, donde está `go.mod`): `open-pull-requests-limit: 0` → **solo security updates** (PRs por CVE/advisory), sin bumps de rutina. Replica el patrón de los repos npm de la org.
- **`github-actions`** (`directory: /`): **version updates activos** para mantener al día las versiones de las actions usadas en los workflows (`docs.yml`, `release.yml`), que hoy están desfasadas (ej. `actions/checkout` aparece en v3.3.0 y v7.0.0). Dependabot actualiza incluso actions pineadas por SHA (actualiza SHA + comentario de versión).
- Ambos: agrupados (un PR por ecosystem) y agendados semanalmente.

## Nota

`open-pull-requests-limit: 0` en `gomod` **no** desactiva la protección de seguridad: los PRs de CVE siguen fluyendo (ignoran ese límite); solo silencia los bumps de rutina.

`github-actions` actualiza versiones de actions (`uses:`), no la imagen del runner (`runs-on: ubuntu-24.04`), que Dependabot no gestiona.