### PR TITLE
feat(notification_channel): add bitbucket channel support

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -37,6 +37,13 @@ resource "nullplatform_account" "gitlab_account" {
   slug                = "gitlab-account"
 }
 
+resource "nullplatform_account" "bitbucket_account" {
+  name                = "My Bitbucket Account"
+  repository_prefix   = "my-workspace"
+  repository_provider = "bitbucket"
+  slug                = "bitbucket-account"
+}
+
 output "github_account_id" {
   description = "The ID of the GitHub account"
   value       = nullplatform_account.github_account.id

--- a/docs/resources/notification_channel.md
+++ b/docs/resources/notification_channel.md
@@ -69,6 +69,21 @@ resource "nullplatform_notification_channel" "github" {
   }
 }
 
+resource "nullplatform_notification_channel" "bitbucket" {
+  nrn    = "organization=1:account=2:namespace=3:application=123"
+  type   = "bitbucket"
+  source = ["service"]
+
+  configuration {
+    bitbucket {
+      workspace  = "my-bitbucket-workspace"
+      repository = "my-awesome-repo"
+      reference  = "main"
+      pipeline   = "provisioning" # custom pipeline name from bitbucket-pipelines.yml (pipelines.custom.<name>)
+    }
+  }
+}
+
 resource "nullplatform_notification_channel" "agent" {
   nrn    = "organization=1:account=2:namespace=3:application=123"
   type   = "agent"
@@ -102,6 +117,10 @@ output "github_channel_repository" {
   value = nullplatform_notification_channel.github.configuration[0].github[0].repository
 }
 
+output "bitbucket_channel_pipeline" {
+  value = nullplatform_notification_channel.bitbucket.configuration[0].bitbucket[0].pipeline
+}
+
 output "agent_channel_command" {
   value = nullplatform_notification_channel.custom_agent.configuration[0].agent[0].command[0].data.cmdline
 }
@@ -114,7 +133,7 @@ output "agent_channel_command" {
 
 - `configuration` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--configuration))
 - `source` (List of String)
-- `type` (String) Channel type (slack, http, gitlab, github, azure)
+- `type` (String) Channel type (slack, http, gitlab, github, azure, bitbucket)
 
 ### Optional
 
@@ -138,6 +157,7 @@ Optional:
 
 - `agent` (Block List, Max: 1) (see [below for nested schema](#nestedblock--configuration--agent))
 - `azure` (Block List, Max: 1) (see [below for nested schema](#nestedblock--configuration--azure))
+- `bitbucket` (Block List, Max: 1) (see [below for nested schema](#nestedblock--configuration--bitbucket))
 - `github` (Block List, Max: 1) (see [below for nested schema](#nestedblock--configuration--github))
 - `gitlab` (Block List, Max: 1) (see [below for nested schema](#nestedblock--configuration--gitlab))
 - `http` (Block List, Max: 1) (see [below for nested schema](#nestedblock--configuration--http))
@@ -174,6 +194,17 @@ Required:
 - `pipeline_id` (Number)
 - `project` (String)
 - `reference` (String)
+
+
+<a id="nestedblock--configuration--bitbucket"></a>
+### Nested Schema for `configuration.bitbucket`
+
+Required:
+
+- `pipeline` (String)
+- `reference` (String)
+- `repository` (String)
+- `workspace` (String)
 
 
 <a id="nestedblock--configuration--github"></a>

--- a/examples/resources/nullplatform_account/resource.tf
+++ b/examples/resources/nullplatform_account/resource.tf
@@ -22,6 +22,13 @@ resource "nullplatform_account" "gitlab_account" {
   slug                = "gitlab-account"
 }
 
+resource "nullplatform_account" "bitbucket_account" {
+  name                = "My Bitbucket Account"
+  repository_prefix   = "my-workspace"
+  repository_provider = "bitbucket"
+  slug                = "bitbucket-account"
+}
+
 output "github_account_id" {
   description = "The ID of the GitHub account"
   value       = nullplatform_account.github_account.id

--- a/examples/resources/nullplatform_notification_channel/resource.tf
+++ b/examples/resources/nullplatform_notification_channel/resource.tf
@@ -54,6 +54,21 @@ resource "nullplatform_notification_channel" "github" {
   }
 }
 
+resource "nullplatform_notification_channel" "bitbucket" {
+  nrn    = "organization=1:account=2:namespace=3:application=123"
+  type   = "bitbucket"
+  source = ["service"]
+
+  configuration {
+    bitbucket {
+      workspace  = "my-bitbucket-workspace"
+      repository = "my-awesome-repo"
+      reference  = "main"
+      pipeline   = "provisioning" # custom pipeline name from bitbucket-pipelines.yml (pipelines.custom.<name>)
+    }
+  }
+}
+
 resource "nullplatform_notification_channel" "agent" {
   nrn    = "organization=1:account=2:namespace=3:application=123"
   type   = "agent"
@@ -85,6 +100,10 @@ output "webhook_channel_url" {
 
 output "github_channel_repository" {
   value = nullplatform_notification_channel.github.configuration[0].github[0].repository
+}
+
+output "bitbucket_channel_pipeline" {
+  value = nullplatform_notification_channel.bitbucket.configuration[0].bitbucket[0].pipeline
 }
 
 output "agent_channel_command" {

--- a/nullplatform/resource_notification_channel.go
+++ b/nullplatform/resource_notification_channel.go
@@ -35,7 +35,7 @@ func resourceNotificationChannel() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Channel type (slack, http, gitlab, github, azure)",
+				Description: "Channel type (slack, http, gitlab, github, azure, bitbucket)",
 			},
 			"source": {
 				Type:     schema.TypeList,
@@ -203,6 +203,31 @@ func resourceNotificationChannel() *schema.Resource {
 								},
 							},
 						},
+						"bitbucket": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"workspace": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"repository": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"reference": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"pipeline": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -291,6 +316,14 @@ func NotificationChannelCreate(d *schema.ResourceData, m any) error {
 			flatConfig["repository"] = githubMap["repository"]
 			flatConfig["workflow_id"] = githubMap["workflow_id"]
 			flatConfig["installation_id"] = githubMap["installation_id"]
+		}
+	case "bitbucket":
+		if bitbucketConfig, ok := config["bitbucket"].([]interface{}); ok && len(bitbucketConfig) > 0 {
+			bitbucketMap := bitbucketConfig[0].(map[string]interface{})
+			flatConfig["workspace"] = bitbucketMap["workspace"]
+			flatConfig["repository"] = bitbucketMap["repository"]
+			flatConfig["reference"] = bitbucketMap["reference"]
+			flatConfig["pipeline"] = bitbucketMap["pipeline"]
 		}
 	}
 
@@ -438,6 +471,15 @@ func NotificationChannelRead(d *schema.ResourceData, m any) error {
 				"installation_id": channel.Configuration["installation_id"],
 			},
 		}
+	case "bitbucket":
+		config["bitbucket"] = []interface{}{
+			map[string]interface{}{
+				"workspace":  channel.Configuration["workspace"],
+				"repository": channel.Configuration["repository"],
+				"reference":  channel.Configuration["reference"],
+				"pipeline":   channel.Configuration["pipeline"],
+			},
+		}
 	}
 
 	if err := d.Set("configuration", []interface{}{config}); err != nil {
@@ -528,6 +570,14 @@ func NotificationChannelUpdate(d *schema.ResourceData, m any) error {
 				flatConfig["repository"] = githubMap["repository"]
 				flatConfig["workflow_id"] = githubMap["workflow_id"]
 				flatConfig["installation_id"] = githubMap["installation_id"]
+			}
+		case "bitbucket":
+			if bitbucketConfig, ok := config["bitbucket"].([]interface{}); ok && len(bitbucketConfig) > 0 {
+				bitbucketMap := bitbucketConfig[0].(map[string]interface{})
+				flatConfig["workspace"] = bitbucketMap["workspace"]
+				flatConfig["repository"] = bitbucketMap["repository"]
+				flatConfig["reference"] = bitbucketMap["reference"]
+				flatConfig["pipeline"] = bitbucketMap["pipeline"]
 			}
 		}
 

--- a/nullplatform/resource_notification_channel_test.go
+++ b/nullplatform/resource_notification_channel_test.go
@@ -17,6 +17,53 @@ import (
 	"github.com/nullplatform/terraform-provider-nullplatform/nullplatform"
 )
 
+// TestNotificationChannelBitbucketSchema asserts the bitbucket configuration
+// block exposes exactly the four required string fields defined by the
+// main-notifications-api PR #161 channel contract (workspace, repository,
+// reference, pipeline). It mirrors the gitlab/github precedent and runs without
+// live API access.
+func TestNotificationChannelBitbucketSchema(t *testing.T) {
+	resourceSchema := nullplatform.Provider().ResourcesMap["nullplatform_notification_channel"].Schema
+
+	configuration, ok := resourceSchema["configuration"]
+	if !ok {
+		t.Fatal("expected notification channel to expose a configuration block")
+	}
+
+	configResource, ok := configuration.Elem.(*schema.Resource)
+	if !ok {
+		t.Fatal("expected configuration Elem to be a *schema.Resource")
+	}
+
+	bitbucket, ok := configResource.Schema["bitbucket"]
+	if !ok {
+		t.Fatal("expected configuration to expose a bitbucket block")
+	}
+
+	bitbucketResource, ok := bitbucket.Elem.(*schema.Resource)
+	if !ok {
+		t.Fatal("expected bitbucket Elem to be a *schema.Resource")
+	}
+
+	expectedFields := []string{"workspace", "repository", "reference", "pipeline"}
+	for _, field := range expectedFields {
+		f, ok := bitbucketResource.Schema[field]
+		if !ok {
+			t.Fatalf("expected bitbucket block to expose required field %q", field)
+		}
+		if !f.Required {
+			t.Errorf("expected bitbucket field %q to be required", field)
+		}
+		if f.Type != schema.TypeString {
+			t.Errorf("expected bitbucket field %q to be a string, got %s", field, f.Type)
+		}
+	}
+
+	if len(bitbucketResource.Schema) != len(expectedFields) {
+		t.Errorf("expected bitbucket block to have exactly %d fields, got %d", len(expectedFields), len(bitbucketResource.Schema))
+	}
+}
+
 func TestAccResourceNotificationChannel(t *testing.T) {
 	applicationID := os.Getenv("NULLPLATFORM_APPLICATION_ID")
 


### PR DESCRIPTION
## Summary

Adds **Bitbucket** as a notification-channel type in the nullplatform Terraform provider, at parity with the existing `gitlab` / `github` / `azure` providers.

This encodes the **final, authoritative channel contract** from the server-side **`main-notifications-api` PR #161**:

- **Channel type wire value:** `bitbucket`
- **`configuration.bitbucket` block — four fields, all Required (string):**
  - `workspace` — Bitbucket Cloud workspace slug
  - `repository` — repository slug
  - `reference` — branch name
  - `pipeline` — the **custom pipeline NAME** from `bitbucket-pipelines.yml` (`pipelines.custom.<name>`) — a name, **not** a numeric id
- **No secrets on the resource.** Credentials are resolved server-side from the NRN (`bitbucket.email` / `apiToken` / `installationUrl`), so the TF resource carries no credentials.

## Changes

- `nullplatform/resource_notification_channel.go`
  - `type` description now lists `bitbucket`.
  - New `bitbucket` configuration schema block (four required string fields), following the gitlab/azure/github block style.
  - `bitbucket` case added to the expand switch (create) and both flatten switches (read + update).
- `nullplatform/resource_notification_channel_test.go`
  - New unit-level schema test `TestNotificationChannelBitbucketSchema` asserting the block exposes exactly the four required string fields (runs without live API access).
- Docs & examples
  - `examples/resources/nullplatform_notification_channel/resource.tf` + `docs/resources/notification_channel.md`: bitbucket resource example, output, schema section, and updated `type` description.
  - `examples/resources/nullplatform_account/resource.tf` + `docs/resources/account.md`: bitbucket account example (`account.repository_provider` is a free-form string that already accepts `bitbucket` — documentation only).

> Note: docs were updated by hand to match what `tfplugindocs` would emit (the sandbox can't fetch the Terraform CLI to regenerate); a future `make update-docs` should be a no-op.

## Sweep for other provider enumerations

Swept the provider for other `github`/`gitlab`/`azure` enumerations. The channel `type` and `account.repository_provider` fields are both free-form strings with **no** restricting `ValidateFunc`; the notification-channel expand/flatten switches were the only real gate. No other provider enumerations require a bitbucket addition.

## Build & tests

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` — new bitbucket schema test passes; `TestProvider_HasChildDataSources` fails identically on `main` (pre-existing, unrelated: 10 registered data sources vs 6 asserted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)