### PR TITLE
fix(provider): only warn about np_apikey/np_api_host when they are configured

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ terraform {
   }
 }
 
-# Use the `NP_API_KEY` environment variable
+# Use the `NULLPLATFORM_API_KEY` environment variable
 provider "nullplatform" {}
 ```
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -7,5 +7,5 @@ terraform {
   }
 }
 
-# Use the `NP_API_KEY` environment variable
+# Use the `NULLPLATFORM_API_KEY` environment variable
 provider "nullplatform" {}

--- a/nullplatform/provider.go
+++ b/nullplatform/provider.go
@@ -15,6 +15,15 @@ const HOST = "host"
 const NP_API_KEY = "np_apikey"
 const NP_API_HOST = "np_api_host"
 
+const DEFAULT_HOST = "api.nullplatform.com"
+
+// Deprecated environment variables, read in getAPIKey/getAPIHost rather than through
+// a schema DefaultFunc: the SDK counts a resolved default as a configured value, so a
+// DefaultFunc on a deprecated attribute makes the deprecation warning fire on every
+// plan for configurations that only ever set the current attribute.
+const NP_API_KEY_ENV = "NP_API_KEY"
+const NP_API_HOST_ENV = "NP_API_HOST"
+
 func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -27,13 +36,12 @@ func Provider() *schema.Provider {
 			},
 			HOST: {
 				Type:        schema.TypeString,
-				DefaultFunc: schema.EnvDefaultFunc("NULLPLATFORM_HOST", "api.nullplatform.com"),
+				DefaultFunc: schema.EnvDefaultFunc("NULLPLATFORM_HOST", nil),
 				Optional:    true,
 				Description: "Nullplatform HOST. Can also be set with the `NULLPLATFORM_HOST` environment variable. If omitted, the default value is `api.nullplatform.com`",
 			},
 			NP_API_KEY: {
 				Type:        schema.TypeString,
-				DefaultFunc: schema.EnvDefaultFunc("NP_API_KEY", nil),
 				Optional:    true,
 				Sensitive:   true,
 				Description: "Nullplatform API KEY. Can also be set with the `NP_API_KEY` environment variable.",
@@ -41,7 +49,6 @@ func Provider() *schema.Provider {
 			},
 			NP_API_HOST: {
 				Type:        schema.TypeString,
-				DefaultFunc: schema.EnvDefaultFunc("NP_API_HOST", nil),
 				Optional:    true,
 				Description: "Nullplatform API HOSTNAME. Can also be set with the `NP_API_HOST` environment variable. If omitted, the default value is `api.nullplatform.com`",
 				Deprecated:  "The 'np_api_host' attribute is deprecated and will be removed in a future version. Please use 'host' instead.",
@@ -138,6 +145,14 @@ func getAPIKey(d *schema.ResourceData) (string, diag.Diagnostics) {
 		})
 		return v.(string), diags
 	}
+	if v := os.Getenv(NP_API_KEY_ENV); v != "" {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Deprecated API Key Environment Variable",
+			Detail:   "You are using the deprecated 'NP_API_KEY' environment variable. Please use 'NULLPLATFORM_API_KEY' instead.",
+		})
+		return v, diags
+	}
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Error,
 		Summary:  "Missing API Key",
@@ -159,12 +174,15 @@ func getAPIHost(d *schema.ResourceData) (string, diag.Diagnostics) {
 		})
 		return v.(string), diags
 	}
-	diags = append(diags, diag.Diagnostic{
-		Severity: diag.Error,
-		Summary:  "Missing API Host",
-		Detail:   "Either 'host' or 'np_api_host' must be set. Please provide a host for authentication.",
-	})
-	return "", diags
+	if v := os.Getenv(NP_API_HOST_ENV); v != "" {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Deprecated Host Environment Variable",
+			Detail:   "You are using the deprecated 'NP_API_HOST' environment variable. Please use 'NULLPLATFORM_HOST' instead.",
+		})
+		return v, diags
+	}
+	return DEFAULT_HOST, diags
 }
 
 func hasErrors(diags diag.Diagnostics) bool {

--- a/nullplatform/provider_test.go
+++ b/nullplatform/provider_test.go
@@ -1,10 +1,13 @@
 package nullplatform_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nullplatform/terraform-provider-nullplatform/nullplatform"
@@ -98,4 +101,110 @@ func TestProvider_HasChildDataSources(t *testing.T) {
 		require.NotNil(t, dataSources[resource], "A data source cannot have a nil schema")
 	}
 	require.Equal(t, len(expectedDataSources), len(dataSources), "There are an unexpected number of registered data sources")
+}
+
+// A deprecated attribute backed by a DefaultFunc is reported by the SDK as configured
+// as soon as the environment variable exists, so every plan warned about 'np_apikey'
+// even for configurations that only set 'api_key'.
+func TestProvider_LegacyEnvVarsDoNotDeprecateCurrentConfig(t *testing.T) {
+	t.Setenv("NP_API_KEY", "legacy-env-key")
+	t.Setenv("NP_API_HOST", "legacy.nullplatform.com")
+
+	diags := provider().Validate(terraform.NewResourceConfigRaw(map[string]any{
+		nullplatform.API_KEY: "current-key",
+	}))
+
+	require.Empty(t, diags, "a configuration using only current attributes must not raise diagnostics")
+}
+
+func TestProvider_DeprecatedAttributesInConfigStillWarn(t *testing.T) {
+	for _, attribute := range []string{nullplatform.NP_API_KEY, nullplatform.NP_API_HOST} {
+		t.Run(attribute, func(t *testing.T) {
+			diags := provider().Validate(terraform.NewResourceConfigRaw(map[string]any{
+				attribute: "some-value",
+			}))
+
+			require.Len(t, diags, 1)
+			require.Equal(t, diag.Warning, diags[0].Severity)
+			require.Equal(t, "Argument is deprecated", diags[0].Summary)
+		})
+	}
+}
+
+func TestProvider_ConfigureResolvesAPIKeyAndHost(t *testing.T) {
+	envNames := []string{"NULLPLATFORM_API_KEY", "NULLPLATFORM_HOST", "NP_API_KEY", "NP_API_HOST"}
+
+	cases := []struct {
+		name         string
+		config       map[string]any
+		env          map[string]string
+		wantAPIKey   string
+		wantHost     string
+		wantWarnings []string
+	}{
+		{
+			name:       "current attribute wins over the legacy environment variable",
+			config:     map[string]any{nullplatform.API_KEY: "config-key"},
+			env:        map[string]string{"NP_API_KEY": "legacy-env-key"},
+			wantAPIKey: "config-key",
+			wantHost:   nullplatform.DEFAULT_HOST,
+		},
+		{
+			name:       "current environment variables",
+			config:     map[string]any{},
+			env:        map[string]string{"NULLPLATFORM_API_KEY": "env-key", "NULLPLATFORM_HOST": "custom.nullplatform.com"},
+			wantAPIKey: "env-key",
+			wantHost:   "custom.nullplatform.com",
+		},
+		{
+			name:         "legacy environment variables are honored with a warning",
+			config:       map[string]any{},
+			env:          map[string]string{"NP_API_KEY": "legacy-env-key", "NP_API_HOST": "legacy.nullplatform.com"},
+			wantAPIKey:   "legacy-env-key",
+			wantHost:     "legacy.nullplatform.com",
+			wantWarnings: []string{"Deprecated API Key Environment Variable", "Deprecated Host Environment Variable"},
+		},
+		{
+			name:         "legacy attributes are honored with a warning",
+			config:       map[string]any{nullplatform.NP_API_KEY: "legacy-key", nullplatform.NP_API_HOST: "legacy-attr.nullplatform.com"},
+			wantAPIKey:   "legacy-key",
+			wantHost:     "legacy-attr.nullplatform.com",
+			wantWarnings: []string{"Deprecated API Key Usage", "Deprecated Host Usage"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear every variable first: the test host may export the legacy ones.
+			for _, name := range envNames {
+				t.Setenv(name, tc.env[name])
+			}
+
+			p := provider()
+			diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(tc.config))
+			require.False(t, diags.HasError(), "configure must not fail: %v", diags)
+
+			client, ok := p.Meta().(*nullplatform.NullClient)
+			require.True(t, ok, "provider meta must be a *NullClient")
+			require.Equal(t, tc.wantAPIKey, client.ApiKey)
+			require.Equal(t, tc.wantHost, client.ApiURL)
+
+			summaries := make([]string, 0, len(diags))
+			for _, d := range diags {
+				summaries = append(summaries, d.Summary)
+			}
+			require.ElementsMatch(t, tc.wantWarnings, summaries)
+		})
+	}
+}
+
+func TestProvider_ConfigureFailsWithoutAPIKey(t *testing.T) {
+	for _, name := range []string{"NULLPLATFORM_API_KEY", "NP_API_KEY"} {
+		t.Setenv(name, "")
+	}
+
+	diags := provider().Configure(context.Background(), terraform.NewResourceConfigRaw(map[string]any{}))
+
+	require.True(t, diags.HasError())
+	require.Equal(t, "Missing API Key", diags[0].Summary)
 }


### PR DESCRIPTION
## Summary

Three things, in order of importance:

**1. It silences a warning nobody can turn off.** Anyone with `NP_API_KEY` exported — which is what our own docs, examples and tooling tell people to do — gets a deprecation warning on *every* `plan` and `apply`, even with a provider block that is already fully migrated:

```hcl
provider "nullplatform" {
  api_key = var.np_api_key  # nothing deprecated here, still warns
}
```

There is no configuration change that makes it stop.

**2. It fixes the cause, not the message.** `Deprecated` and `DefaultFunc` on the same attribute are incompatible in the plugin SDK: the deprecation fires when the SDK *resolves a value*, not when the attribute *is present in the configuration*. Dropping the `DefaultFunc` and reading the legacy environment variables explicitly keeps `NP_API_KEY` authenticating exactly as before, while the warning now names the environment variable — the thing the user actually has to change — and only when it is what supplied the value.

**3. It uncovers dead configuration.** Moving `np_api_host` off its `DefaultFunc` exposed that `host` carried a non-nil default, so `GetOk(host)` was always true and both `np_api_host` and `NP_API_HOST` were silently ignored — the `Missing API Host` error was unreachable code. The documented precedence now actually holds. This is a real behavior change and has [its own section below](#behavior-change-worth-a-second-look).

Net effect per setup:

| Setup | Before | After |
| --- | --- | --- |
| `api_key` / `host` attributes only | warns on every plan, unactionable | clean plan |
| `NP_API_KEY` exported | warns about the *attribute* | warns about the *environment variable* |
| `NP_API_HOST` exported | silently ignored | honored, with a deprecation warning |
| `np_apikey` / `np_api_host` in config | warns | unchanged |

Nobody loses a way to authenticate that works today.

## Problem

Every `plan`/`apply` emits a deprecation warning for `np_apikey` even when the configuration never mentions it:

```
Warning: Argument is deprecated

  with provider["registry.opentofu.org/nullplatform/nullplatform"],
  on provider.tf line 21, in provider "nullplatform":
  21: provider "nullplatform" {

The 'np_apikey' attribute is deprecated and will be removed in a future version.
Please use 'api_key' instead.
```

The provider block that triggers it is already migrated:

```hcl
provider "nullplatform" {
  api_key = var.np_api_key
}
```

The tell is the source range: the diagnostic points at the block header instead of at an attribute line, because the attribute is nowhere in the configuration. The only requirement to reproduce is having `NP_API_KEY` exported in the environment — which is what our own docs, examples and tooling tell people to do. So the warning is unactionable: there is no configuration change that silences it.

## Root cause

Both deprecated attributes were backed by a `DefaultFunc`:

```go
NP_API_KEY: {
    DefaultFunc: schema.EnvDefaultFunc("NP_API_KEY", nil),
    Deprecated:  "The 'np_apikey' attribute is deprecated ...",
},
```

`schemaMap.validate` resolves the `DefaultFunc` when a key is absent from the config and then treats the resolved value as configured ([schema.go#L1833-L1849](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/schema.go#L1833-L1849)):

```go
raw, ok := c.Get(k)
if !ok && schema.DefaultFunc != nil {
    raw, err = schema.DefaultFunc()
    // We're okay as long as we had a value set
    ok = raw != nil
}
```

With `ok == true` it falls through to `validateType`, which appends the schema's `Deprecated` message ([schema.go#L2515](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/schema.go#L2515)). `Deprecated` + `DefaultFunc` on the same field means the deprecation fires on *value resolution*, not on *presence in the configuration*.

## Change

Drop the `DefaultFunc` from `np_apikey`/`np_api_host` and read the legacy environment variables explicitly in `getAPIKey`/`getAPIHost`, where the fallback chain already lives:

| Source | Before | After |
| --- | --- | --- |
| `api_key` / `host` attribute | used | used, no diagnostics |
| `NULLPLATFORM_API_KEY` / `NULLPLATFORM_HOST` | used | unchanged |
| `np_apikey` / `np_api_host` attribute | used, warns | unchanged |
| `NP_API_KEY` / `NP_API_HOST` env var | used, warns **about the attribute** on any config | used, warns **about the environment variable**, and only when it is what supplied the value |

Nothing is dropped: `NP_API_KEY` keeps authenticating exactly as before. Users who already migrated to `api_key` get a clean plan, and users still on the legacy env var get a warning that names what they actually have to change.

## Behavior change worth a second look

Removing `np_api_host`'s `DefaultFunc` exposed that the legacy host input was dead config. `host` carried a non-nil default (`schema.EnvDefaultFunc("NULLPLATFORM_HOST", "api.nullplatform.com")`), so `d.GetOk(HOST)` was always true and `getAPIHost` returned before ever looking at `np_api_host` — both the attribute and `NP_API_HOST` were silently ignored, and the `Missing API Host` error was unreachable.

The default now lives in `getAPIHost` (`DEFAULT_HOST`), so the documented precedence actually holds: `host` → `NULLPLATFORM_HOST` → `np_api_host` → `NP_API_HOST` → `api.nullplatform.com`. **This means someone who exports `NP_API_HOST` and relies on it being ignored would now be pointed at that host.** That is what the attribute has always claimed to do, but it is a real behavior change and the reason it is called out here rather than buried.

## Verification

New tests in `nullplatform/provider_test.go`, all of which fail against `main`:

- `TestProvider_LegacyEnvVarsDoNotDeprecateCurrentConfig` — reproduces the reported bug through `Provider().Validate()`. Against `main` it fails with the exact two warnings from the issue.
- `TestProvider_DeprecatedAttributesInConfigStillWarn` — the deprecation still fires when the attribute *is* in the configuration.
- `TestProvider_ConfigureResolvesAPIKeyAndHost` — table over the full precedence chain, asserting the resolved `NullClient.ApiKey`/`ApiURL` and the exact set of warnings.
- `TestProvider_ConfigureFailsWithoutAPIKey` — the missing-key error is preserved.

```
$ go test ./...
?   github.com/nullplatform/terraform-provider-nullplatform   [no test files]
ok  github.com/nullplatform/terraform-provider-nullplatform/nullplatform  1.077s
```

End to end against a real configuration with `NP_API_KEY` exported, via `dev_overrides`:

```
released v0.0.95      -> 1 np_apikey deprecation warning
this branch           -> 0
```

`examples/provider/provider.tf` (rendered into `docs/index.md`) advertised the deprecated `NP_API_KEY`; it now points at `NULLPLATFORM_API_KEY`. Docs were hand-edited to match, since `tfplugindocs` v0.16.0 cannot run locally without a `terraform` binary — the `docs` workflow will confirm.
