### PR TITLE
fix: let use_default_actions=false reach the API (tri-state), add use_default_naming

### DIFF
--- a/docs/data-sources/service_specification.md
+++ b/docs/data-sources/service_specification.md
@@ -51,6 +51,7 @@ output "service_specification_name" {
 - `slug` (String) The computed slug for the service specification.
 - `type` (String) Type of the service specification.
 - `use_default_actions` (Boolean) Indicates whether the service specification uses default actions.
+- `use_default_naming` (Boolean) Indicates whether the entry point of the service specification actions is derived from the default naming convention.
 - `visible_to` (List of String) Array representing visibility settings for the service specification.
 
 <a id="nestedatt--selectors"></a>

--- a/docs/resources/link_specification.md
+++ b/docs/resources/link_specification.md
@@ -77,7 +77,8 @@ resource "nullplatform_link_specification" "redis_link_spec" {
 - `external` (String) JSON string with the configuration for resolving external context data via the nullplatform agent
 - `scopes` (String) JSON string containing scope configurations. Example: {"provider": {"values": ["AWS:SERVERLESS:LAMBDA"]}}
 - `selectors` (Block List, Max: 1) Selectors for the service specification (see [below for nested schema](#nestedblock--selectors))
-- `use_default_actions` (Boolean) Indicates whether to use default actions for the link specification
+- `use_default_actions` (Boolean) Indicates whether to use default actions for the link specification. Left to the API default when not set
+- `use_default_naming` (Boolean) Indicates whether the entry point of the link specification actions is derived from the default naming convention (`<service-slug>/link/<action-slug>`). Left to the API default when not set
 - `visible_to` (List of String) Array representing visibility settings for the link specification
 
 ### Read-Only

--- a/docs/resources/service_specification.md
+++ b/docs/resources/service_specification.md
@@ -101,7 +101,8 @@ resource "nullplatform_service_specification" "redis_service_spec" {
 - `scopes` (String) JSON string containing scope configurations. Example: {"provider": {"values": ["AWS:SERVERLESS:LAMBDA"]}}
 - `selectors` (Block List, Max: 1) Selectors for the service specification (see [below for nested schema](#nestedblock--selectors))
 - `type` (String) Type of the service specification
-- `use_default_actions` (Boolean) Indicates whether to use default actions for the service specification
+- `use_default_actions` (Boolean) Indicates whether to use default actions for the service specification. Left to the API default when not set
+- `use_default_naming` (Boolean) Indicates whether the entry point of the service specification actions is derived from the default naming convention based on the service and action slugs. Left to the API default when not set
 
 ### Read-Only
 

--- a/nullplatform/data_source_service_specification.go
+++ b/nullplatform/data_source_service_specification.go
@@ -60,6 +60,11 @@ func dataSourceServiceSpecification() *schema.Resource {
 				Computed:    true,
 				Description: "Indicates whether the service specification uses default actions.",
 			},
+			"use_default_naming": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the entry point of the service specification actions is derived from the default naming convention.",
+			},
 			"scopes": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,8 +116,15 @@ func dataSourceServiceSpecificationRead(_ context.Context, d *schema.ResourceDat
 	if err := d.Set("visible_to", spec.VisibleTo); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("use_default_actions", spec.UseDefaultActions); err != nil {
-		return diag.FromErr(err)
+	if spec.UseDefaultActions != nil {
+		if err := d.Set("use_default_actions", *spec.UseDefaultActions); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if spec.UseDefaultNaming != nil {
+		if err := d.Set("use_default_naming", *spec.UseDefaultNaming); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if err := d.Set("assignable_to", spec.AssignableTo); err != nil {
 		return diag.FromErr(err)

--- a/nullplatform/link_specification.go
+++ b/nullplatform/link_specification.go
@@ -12,6 +12,10 @@ const (
 	LINK_SPECIFICATION_PATH = "/link_specification"
 )
 
+// LinkSpecification models the API payload. UseDefaultActions and
+// UseDefaultNaming are pointers rather than plain bools because omitempty drops
+// a false bool, which made an explicit false impossible to transmit; nil means
+// the attribute was not configured and the API default applies.
 type LinkSpecification struct {
 	Id                 string                 `json:"id,omitempty"`
 	Name               string                 `json:"name,omitempty"`
@@ -23,7 +27,8 @@ type LinkSpecification struct {
 	AssignableTo       string                 `json:"assignable_to,omitempty"`
 	Attributes         map[string]interface{} `json:"attributes,omitempty"`
 	Selectors          *Selectors             `json:"selectors,omitempty"`
-	UseDefaultActions  bool                   `json:"use_default_actions,omitempty"`
+	UseDefaultActions  *bool                  `json:"use_default_actions,omitempty"`
+	UseDefaultNaming   *bool                  `json:"use_default_naming,omitempty"`
 	Scopes             map[string]interface{} `json:"scopes,omitempty"`
 	External           map[string]interface{} `json:"external,omitempty"`
 	ExternalResolution map[string]interface{} `json:"external_resolution,omitempty"`

--- a/nullplatform/resource_link_specification.go
+++ b/nullplatform/resource_link_specification.go
@@ -86,8 +86,14 @@ func resourceLinkSpecification() *schema.Resource {
 			"use_default_actions": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
-				Description: "Indicates whether to use default actions for the link specification",
+				Computed:    true,
+				Description: "Indicates whether to use default actions for the link specification. Left to the API default when not set",
+			},
+			"use_default_naming": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether the entry point of the link specification actions is derived from the default naming convention (`<service-slug>/link/<action-slug>`). Left to the API default when not set",
 			},
 			"scopes": {
 				Type:             schema.TypeString,
@@ -192,7 +198,8 @@ func CreateLinkSpecification(_ context.Context, d *schema.ResourceData, m interf
 		AssignableTo:      d.Get("assignable_to").(string),
 		Attributes:        attributes,
 		Selectors:         &selectors,
-		UseDefaultActions: d.Get("use_default_actions").(bool),
+		UseDefaultActions: configuredBool(d, "use_default_actions"),
+		UseDefaultNaming:  configuredBool(d, "use_default_naming"),
 		Scopes:            scopes,
 	}
 
@@ -237,8 +244,15 @@ func ReadLinkSpecification(_ context.Context, d *schema.ResourceData, m interfac
 	if err := d.Set("visible_to", spec.VisibleTo); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("use_default_actions", spec.UseDefaultActions); err != nil {
-		return diag.FromErr(err)
+	if spec.UseDefaultActions != nil {
+		if err := d.Set("use_default_actions", *spec.UseDefaultActions); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if spec.UseDefaultNaming != nil {
+		if err := d.Set("use_default_naming", *spec.UseDefaultNaming); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	dimensionsJSON, err := json.Marshal(spec.Dimensions)
@@ -316,6 +330,14 @@ func UpdateLinkSpecification(ctx context.Context, d *schema.ResourceData, m inte
 
 	spec.Unique = d.Get("unique").(bool)
 
+	// Send these two whenever the configuration declares them, not only on
+	// change, so that flipping true -> false actually reaches the API. When the
+	// attribute is absent the helper yields nil, keeping it out of the PATCH
+	// body: gating on d.HasChange instead would leave the Go zero value behind
+	// and turn the flag off on unrelated updates.
+	spec.UseDefaultActions = configuredBool(d, "use_default_actions")
+	spec.UseDefaultNaming = configuredBool(d, "use_default_naming")
+
 	if d.HasChange("visible_to") {
 		if v, ok := d.GetOk("visible_to"); ok {
 			visibleToRaw := v.([]interface{})
@@ -325,10 +347,6 @@ func UpdateLinkSpecification(ctx context.Context, d *schema.ResourceData, m inte
 			}
 			spec.VisibleTo = visibleTo
 		}
-	}
-
-	if d.HasChange("use_default_actions") {
-		spec.UseDefaultActions = d.Get("use_default_actions").(bool)
 	}
 
 	if d.HasChange("dimensions") {

--- a/nullplatform/resource_service_specification.go
+++ b/nullplatform/resource_service_specification.go
@@ -93,8 +93,14 @@ func resourceServiceSpecification() *schema.Resource {
 			"use_default_actions": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
-				Description: "Indicates whether to use default actions for the service specification",
+				Computed:    true,
+				Description: "Indicates whether to use default actions for the service specification. Left to the API default when not set",
+			},
+			"use_default_naming": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Indicates whether the entry point of the service specification actions is derived from the default naming convention based on the service and action slugs. Left to the API default when not set",
 			},
 			"scopes": {
 				Type:             schema.TypeString,
@@ -185,7 +191,8 @@ func CreateServiceSpecification(_ context.Context, d *schema.ResourceData, m int
 		Type:              d.Get("type").(string),
 		Attributes:        attributes,
 		Selectors:         &selectors,
-		UseDefaultActions: d.Get("use_default_actions").(bool),
+		UseDefaultActions: configuredBool(d, "use_default_actions"),
+		UseDefaultNaming:  configuredBool(d, "use_default_naming"),
 		Scopes:            scopes,
 	}
 
@@ -226,8 +233,15 @@ func ReadServiceSpecification(_ context.Context, d *schema.ResourceData, m inter
 	if err := d.Set("visible_to", spec.VisibleTo); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("use_default_actions", spec.UseDefaultActions); err != nil {
-		return diag.FromErr(err)
+	if spec.UseDefaultActions != nil {
+		if err := d.Set("use_default_actions", *spec.UseDefaultActions); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if spec.UseDefaultNaming != nil {
+		if err := d.Set("use_default_naming", *spec.UseDefaultNaming); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	dimensionsJSON, err := json.Marshal(spec.Dimensions)
@@ -282,6 +296,14 @@ func UpdateServiceSpecification(ctx context.Context, d *schema.ResourceData, m i
 
 	spec := &ServiceSpecification{}
 
+	// Send these two whenever the configuration declares them, not only on
+	// change, so that flipping true -> false actually reaches the API. When the
+	// attribute is absent the helper yields nil, keeping it out of the PATCH
+	// body: gating on d.HasChange instead would leave the Go zero value behind
+	// and turn the flag off on unrelated updates.
+	spec.UseDefaultActions = configuredBool(d, "use_default_actions")
+	spec.UseDefaultNaming = configuredBool(d, "use_default_naming")
+
 	if d.HasChange("name") {
 		spec.Name = d.Get("name").(string)
 	}
@@ -297,10 +319,6 @@ func UpdateServiceSpecification(ctx context.Context, d *schema.ResourceData, m i
 			visibleTo[i] = v.(string)
 		}
 		spec.VisibleTo = visibleTo
-	}
-
-	if d.HasChange("use_default_actions") {
-		spec.UseDefaultActions = d.Get("use_default_actions").(bool)
 	}
 
 	if d.HasChange("dimensions") {

--- a/nullplatform/service_specification.go
+++ b/nullplatform/service_specification.go
@@ -19,6 +19,10 @@ type Selectors struct {
 	SubCategory string `json:"sub_category"`
 }
 
+// ServiceSpecification models the API payload. UseDefaultActions and
+// UseDefaultNaming are pointers rather than plain bools because omitempty drops
+// a false bool, which made an explicit false impossible to transmit; nil means
+// the attribute was not configured and the API default applies.
 type ServiceSpecification struct {
 	Id                string                 `json:"id,omitempty"`
 	Name              string                 `json:"name,omitempty"`
@@ -30,7 +34,8 @@ type ServiceSpecification struct {
 	Type              string                 `json:"type,omitempty"`
 	Attributes        map[string]interface{} `json:"attributes,omitempty"`
 	Selectors         *Selectors             `json:"selectors,omitempty"` // Use the new struct
-	UseDefaultActions bool                   `json:"use_default_actions,omitempty"`
+	UseDefaultActions *bool                  `json:"use_default_actions,omitempty"`
+	UseDefaultNaming  *bool                  `json:"use_default_naming,omitempty"`
 	Scopes            map[string]interface{} `json:"scopes,omitempty"`
 }
 

--- a/nullplatform/specification_defaults_test.go
+++ b/nullplatform/specification_defaults_test.go
@@ -1,0 +1,104 @@
+package nullplatform
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSpecificationDefaultFlagsSerialization pins the tri-state contract of
+// use_default_actions and use_default_naming: an explicit true or false must
+// reach the API, and an unconfigured attribute must stay out of the request
+// body so the API keeps applying its own default.
+//
+// Root cause of the original bug: both fields were plain `bool` tagged with
+// `omitempty`, and encoding/json drops such a field when it holds the zero
+// value. Omitting the attribute and setting it to false produced the exact same
+// payload, the backend then applied its own default (true), and disabling
+// default actions from Terraform was impossible. Modelling them as *bool keeps
+// omitempty working for the unset case while letting false through.
+func TestSpecificationDefaultFlagsSerialization(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	for _, tt := range []struct {
+		name string
+		set  *bool
+	}{
+		{name: "explicit false", set: boolPtr(false)},
+		{name: "explicit true", set: boolPtr(true)},
+		{name: "unset", set: nil},
+	} {
+		t.Run("link/"+tt.name, func(t *testing.T) {
+			body := captureRequestBody(t, func(c *NullClient) {
+				if _, err := c.CreateLinkSpecification(&LinkSpecification{
+					Name:              "test",
+					UseDefaultActions: tt.set,
+					UseDefaultNaming:  tt.set,
+				}); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			assertOptionalBoolField(t, body, "use_default_actions", tt.set)
+			assertOptionalBoolField(t, body, "use_default_naming", tt.set)
+		})
+
+		t.Run("service/"+tt.name, func(t *testing.T) {
+			body := captureRequestBody(t, func(c *NullClient) {
+				if _, err := c.CreateServiceSpecification(&ServiceSpecification{
+					Name:              "test",
+					UseDefaultActions: tt.set,
+					UseDefaultNaming:  tt.set,
+				}); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			assertOptionalBoolField(t, body, "use_default_actions", tt.set)
+			assertOptionalBoolField(t, body, "use_default_naming", tt.set)
+		})
+	}
+}
+
+func captureRequestBody(t *testing.T, call func(*NullClient)) map[string]any {
+	t.Helper()
+
+	var raw []byte
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"spec-123"}`))
+	}))
+	defer server.Close()
+
+	call(newTestClient(server))
+
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("failed to decode captured request body %q: %v", raw, err)
+	}
+	return body
+}
+
+// assertOptionalBoolField checks that field carries *want, or is absent
+// entirely when want is nil.
+func assertOptionalBoolField(t *testing.T, body map[string]any, field string, want *bool) {
+	t.Helper()
+
+	got, present := body[field]
+
+	if want == nil {
+		if present {
+			t.Errorf("%q present as %v in request body %v: an unconfigured attribute must be omitted so the API default applies", field, got, body)
+		}
+		return
+	}
+
+	if !present {
+		t.Fatalf("%q missing from request body %v: a bool that must transmit false cannot be a plain bool with omitempty", field, body)
+	}
+	if got != *want {
+		t.Errorf("%q = %v, want %v", field, got, *want)
+	}
+}

--- a/nullplatform/utils.go
+++ b/nullplatform/utils.go
@@ -4,7 +4,30 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+// configuredBool reports an Optional+Computed boolean attribute only when the
+// practitioner actually declared it in the configuration, returning nil
+// otherwise so the caller can leave the field out of the request body and let
+// the API keep applying its own default.
+//
+// d.Get cannot make this distinction: an omitted bool and an explicit false
+// both read back as false, so the raw configuration has to be consulted. The
+// value itself still comes from d.Get, which is always resolved by the time
+// create and update run.
+func configuredBool(d *schema.ResourceData, key string) *bool {
+	raw := d.GetRawConfig()
+	if raw.IsNull() {
+		return nil
+	}
+	if attr := raw.GetAttr(key); attr.IsNull() {
+		return nil
+	}
+	v := d.Get(key).(bool)
+	return &v
+}
 
 func serializeHelper(value any) (any, error) {
 	rv := reflect.ValueOf(value)


### PR DESCRIPTION
## Problem

`use_default_actions` cannot be set to `false` from Terraform. Both specification structs tagged the field with `omitempty` on a `bool`:

```go
UseDefaultActions bool `json:"use_default_actions,omitempty"`
```

`encoding/json` drops a field tagged `omitempty` when it holds the zero value, and the request body is a plain struct encode (`json.NewEncoder(&buf).Encode(*s)`). Writing `false` and omitting the attribute produce the **identical** payload — field absent.

The sibling `unique` field on `LinkSpecification` was already tagged without `omitempty` for exactly this reason.

**A specification therefore gets created with the API default and can never be moved off it.** The value the practitioner wrote is discarded on create and discarded again on every subsequent apply, so the attribute is effectively read-only from Terraform in one direction: it can be set to `true`, never back to `false`.

Observed on a live organization. A service specification whose configuration declares `use_default_actions = false` reads back from the API as `true`, together with its link specification. The audit trail of the creation request shows why:

```
request keys: assignable_to, attributes, dimensions, name,
              selectors, type, use_default_naming, visible_to

use_default_actions  ->  absent from the body
response             ->  "use_default_actions": true
```

The attribute never left the provider, and the API applied its default.

The symptom that surfaced this was a link whose action failed on a script the practitioner never declared, the entry point having been derived from the naming convention (`<service-slug>/link/<action-slug>`):

```text
info: Executing action script... vault/link/create-vault
info: /tmp/script-2745562182: 63: vault/link/create-vault: not found
info: Script finished with status 127
```

Nothing in that output hints that the attribute was never sent.

Which of the two attributes governs that derivation was not established. Setting `use_default_actions` to `false` through the API did not stop it, and the synthesized action specification has no audit trail and appears in no listing, so it cannot be inspected or removed by the practitioner. `use_default_naming` is the remaining candidate. Both are unreachable from Terraform today, which is why this change covers both rather than only the one named in the report.

## Approach

Both flags are modelled as `*bool` with `Optional + Computed`:

| Configuration | Request body |
|---|---|
| `use_default_actions = false` | `false` |
| `use_default_actions = true` | `true` |
| attribute omitted | field absent — the API applies its own default |

`omitempty` is kept: on a pointer it drops only `nil`, not `false`.

Presence is detected through `GetRawConfig`, following the existing `configuredDefaultVersion` helper in `resource_package.go`, because `d.Get` reports an omitted bool and an explicit `false` identically. The value still comes from `d.Get`, which is resolved by the time create and update run.

### Why not a plain bool with the schema default flipped to `true`

That was implemented first and rejected. It forces the provider to hardcode an assumption about the API's default and to transmit that value for every configuration that omits the attribute.

The API default is `true`, confirmed from the audit trail of the creation request above: the POST body carried no `use_default_actions` key and the response came back `true`. But pinning the schema default to match is still the wrong shape. It makes the provider transmit a value the practitioner never wrote, which silently overwrites whatever the API or another tool had set — and in the organization examined, 75 of 78 service specifications carry `false`, written by a client that posts the specification JSON directly rather than through this provider. A schema default of `true` would fight that tooling on every apply.

The pointer model never transmits a value the configuration does not declare, so it is correct regardless of what the API default happens to be.

## Changes

- **`configuredBool` helper** in `utils.go`, mirroring the established `configuredDefaultVersion` pattern.
- **`UseDefaultActions` and `UseDefaultNaming` as `*bool`** in `LinkSpecification` and `ServiceSpecification`.
- **Schema `Optional + Computed`**, no `Default`. `Computed` lets the API value settle into state without a diff, which also resolves a **perpetual plan churn**: a read returned the API value while the schema default disagreed, and the apply never converged because the value was stripped from the payload.
- **Update paths assign both flags from the helper instead of gating on `d.HasChange`.** The update functions build a partial struct and relied on `omitempty` to keep untouched fields out of the PATCH body, so a gated assignment would leave the Go zero value behind and turn the flags off on an unrelated change such as a rename. An unset attribute yields `nil` and stays out of the body.
- **`use_default_naming` added**, which the API accepts and returns but the provider did not model at all (zero occurrences before this PR). It controls whether an action entry point is derived from the naming convention.
- **`use_default_naming` exposed on the service specification data source**, next to the `use_default_actions` attribute it already exposed.
- **Regression test** pinning all three states, including that an unconfigured attribute is absent from the payload.
- **Docs regenerated** with `tfplugindocs`.

## Verification

```
go build ./...   OK
go vet ./...     OK
go test ./nullplatform/ -run TestSpecificationDefaultFlagsSerialization
  --- PASS: TestSpecificationDefaultFlagsSerialization (0.01s)
      link/explicit_false  service/explicit_false
      link/explicit_true   service/explicit_true
      link/unset           service/unset
```

`gofmt -l` clean on every file touched. The suite is entirely `httptest`-based — no credentials or network needed. Docs regeneration produced no unrelated churn.

Mutation-checked:

- Removing `omitempty` from the pointer fails the `unset` cases with `"use_default_actions" present as <nil> ...: an unconfigured attribute must be omitted so the API default applies`.
- Reintroducing the original `bool` + `omitempty` shape is now a **compile error**, since the struct fields no longer accept a plain bool.

## Verified against the live API

Both values this change newly transmits were exercised against a real organization:

- **`use_default_actions: false` on PATCH** — applied to a link specification that was stuck on `true`; a fresh read returned `false`. The value is accepted and honoured, not ignored.
- **`use_default_naming` on write** — the audit trail of the creation request shows a client sending `use_default_naming: true` in the POST body, answered `200`, with the field applied. It is a writable attribute, not read-only.

Remaining gap: there are no acceptance tests for `link_specification` or `service_specification` in the repository — the only specification test is `provider_specification`. The regression test added here covers serialization, not API acceptance.

## Pre-existing flaky test, unrelated to this PR

`TestGenerateParameterValueID` fails intermittently on `main` — reproduced 1 in 6 runs on a clean checkout, with this branch stashed. The cause is at `parameter.go:236`:

```go
// Use a specific order for dimensions that matches the test cases
for key, value := range value.Dimensions {
```

The comment states a specific order while the code iterates a Go map, whose order is deliberately randomized. With two dimensions there are two possible concatenations, so the assertion passes roughly half the time.

This is not only a test problem: `generateParameterValueID` produces the Terraform resource ID for `nullplatform_parameter_value`, so the same configuration can yield different IDs across runs. Sorting the keys before concatenating would fix both, but that changes existing IDs and belongs in its own PR.

## Same `omitempty`-on-bool pattern elsewhere — not addressed here

All three break the `true` -> `false` transition in the same way:

| Field | File | Schema default vs API default |
|---|---|---|
| `Retryable` | `action_specification.go:21` | both `false` — create unaffected, only the transition breaks |
| `Parallelize` | `action_specification.go:22` | appears in no published spec |
| `AllowDimensions` | `provider_specification.go:25` | API default not documented |
| `AutoDeployOnCreation`, `IsMonoRepo` | `application.go:20,22` | create-only (`ForceNew`, no update path) |

`retryable` is worth prioritising: `nullplatform/tofu-modules` writes `retryable = try(..., false)` in its `service_definition` module, so a service spec template that sets `true` can never be walked back.

Not affected: `package.go:35` `Default` is a one-shot action flag where omitting on `false` is semantically correct, and `scope.go:41` `ExternalCreated` is only ever assigned the literal `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

