### PR TITLE
feat(specification): use_managed_actions on both specifications

### DIFF
--- a/docs/data-sources/service_specification.md
+++ b/docs/data-sources/service_specification.md
@@ -52,6 +52,7 @@ output "service_specification_name" {
 - `type` (String) Type of the service specification.
 - `use_default_actions` (Boolean) Indicates whether the service specification uses default actions.
 - `use_default_naming` (Boolean) Indicates whether the entry point of the service specification actions is derived from the default naming convention.
+- `use_managed_actions` (Boolean) Indicates whether the CRUD verbs on instances of this specification run through the generated actions instead of writing directly.
 - `visible_to` (List of String) Array representing visibility settings for the service specification.
 
 <a id="nestedatt--selectors"></a>

--- a/docs/resources/link_specification.md
+++ b/docs/resources/link_specification.md
@@ -32,7 +32,10 @@ resource "nullplatform_link_specification" "redis_link_spec" {
     "organization=1255165411:account=*",
   ]
 
-  use_default_actions = true
+  # See the service specification example for the three behaviour flags. New
+  # specifications should take the platform defaults (`use_default_actions` and
+  # `use_default_naming` are both true) and opt into managed CRUD:
+  use_managed_actions = true
 
   scopes = jsonencode({
     provider = {
@@ -79,6 +82,7 @@ resource "nullplatform_link_specification" "redis_link_spec" {
 - `selectors` (Block List, Max: 1) Selectors for the service specification (see [below for nested schema](#nestedblock--selectors))
 - `use_default_actions` (Boolean) Indicates whether to use default actions for the link specification. Left to the API default when not set
 - `use_default_naming` (Boolean) Indicates whether the entry point of the link specification actions is derived from the default naming convention (`<service-slug>/link/<action-slug>`). Left to the API default when not set
+- `use_managed_actions` (Boolean) Indicates whether the CRUD verbs on instances of this specification run through the generated actions instead of writing directly: a PATCH mints the `update` action, a DELETE mints `delete`, and `status = "archived"` mints `archive`. Requires `use_default_actions` — a specification that authors its own actions has none to stamp as managed. Left to the API default (false) when not set
 - `visible_to` (List of String) Array representing visibility settings for the link specification
 
 ### Read-Only

--- a/docs/resources/service_specification.md
+++ b/docs/resources/service_specification.md
@@ -33,7 +33,21 @@ resource "nullplatform_service_specification" "redis_service_spec" {
     "organization=1255165411:account=*",
   ]
 
-  use_default_actions = true
+  # The behaviour flags. All three are optional: leave one out and the
+  # specification tracks the platform's default rather than a provider guess.
+  #
+  #   use_default_actions  default true   platform generates and owns the CRUD actions
+  #   use_default_naming   default true   instance names come from the schema
+  #   use_managed_actions  default false  CRUD verbs run *through* those actions
+  #
+  # Recommended for a new specification: take the two defaults and opt into
+  # managed actions, so a PATCH mints `update`, a DELETE mints `delete`, and
+  # `status = "archived"` mints `archive` instead of writing the row directly.
+  use_managed_actions = true
+
+  # Only set these to depart from the platform default — for example
+  # `use_default_actions = false` to author every action yourself with
+  # nullplatform_action_specification (which also rules out managed actions).
 
   scopes = jsonencode({
     provider = {
@@ -103,6 +117,7 @@ resource "nullplatform_service_specification" "redis_service_spec" {
 - `type` (String) Type of the service specification
 - `use_default_actions` (Boolean) Indicates whether to use default actions for the service specification. Left to the API default when not set
 - `use_default_naming` (Boolean) Indicates whether the entry point of the service specification actions is derived from the default naming convention based on the service and action slugs. Left to the API default when not set
+- `use_managed_actions` (Boolean) Indicates whether the CRUD verbs on instances of this specification run through the generated actions instead of writing directly: a PATCH mints the `update` action, a DELETE mints `delete`, and `status = "archived"` mints `archive`. Requires `use_default_actions` — a specification that authors its own actions has none to stamp as managed. Left to the API default (false) when not set
 
 ### Read-Only
 

--- a/examples/resources/nullplatform_link_specification/resource.tf
+++ b/examples/resources/nullplatform_link_specification/resource.tf
@@ -17,7 +17,10 @@ resource "nullplatform_link_specification" "redis_link_spec" {
     "organization=1255165411:account=*",
   ]
 
-  use_default_actions = true
+  # See the service specification example for the three behaviour flags. New
+  # specifications should take the platform defaults (`use_default_actions` and
+  # `use_default_naming` are both true) and opt into managed CRUD:
+  use_managed_actions = true
 
   scopes = jsonencode({
     provider = {

--- a/examples/resources/nullplatform_service_specification/resource.tf
+++ b/examples/resources/nullplatform_service_specification/resource.tf
@@ -18,7 +18,21 @@ resource "nullplatform_service_specification" "redis_service_spec" {
     "organization=1255165411:account=*",
   ]
 
-  use_default_actions = true
+  # The behaviour flags. All three are optional: leave one out and the
+  # specification tracks the platform's default rather than a provider guess.
+  #
+  #   use_default_actions  default true   platform generates and owns the CRUD actions
+  #   use_default_naming   default true   instance names come from the schema
+  #   use_managed_actions  default false  CRUD verbs run *through* those actions
+  #
+  # Recommended for a new specification: take the two defaults and opt into
+  # managed actions, so a PATCH mints `update`, a DELETE mints `delete`, and
+  # `status = "archived"` mints `archive` instead of writing the row directly.
+  use_managed_actions = true
+
+  # Only set these to depart from the platform default — for example
+  # `use_default_actions = false` to author every action yourself with
+  # nullplatform_action_specification (which also rules out managed actions).
 
   scopes = jsonencode({
     provider = {

--- a/nullplatform/data_source_service_specification.go
+++ b/nullplatform/data_source_service_specification.go
@@ -65,6 +65,11 @@ func dataSourceServiceSpecification() *schema.Resource {
 				Computed:    true,
 				Description: "Indicates whether the entry point of the service specification actions is derived from the default naming convention.",
 			},
+			"use_managed_actions": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the CRUD verbs on instances of this specification run through the generated actions instead of writing directly.",
+			},
 			"scopes": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -123,6 +128,11 @@ func dataSourceServiceSpecificationRead(_ context.Context, d *schema.ResourceDat
 	}
 	if spec.UseDefaultNaming != nil {
 		if err := d.Set("use_default_naming", *spec.UseDefaultNaming); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if spec.UseManagedActions != nil {
+		if err := d.Set("use_managed_actions", *spec.UseManagedActions); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/nullplatform/link_specification.go
+++ b/nullplatform/link_specification.go
@@ -29,6 +29,7 @@ type LinkSpecification struct {
 	Selectors          *Selectors             `json:"selectors,omitempty"`
 	UseDefaultActions  *bool                  `json:"use_default_actions,omitempty"`
 	UseDefaultNaming   *bool                  `json:"use_default_naming,omitempty"`
+	UseManagedActions  *bool                  `json:"use_managed_actions,omitempty"`
 	Scopes             map[string]interface{} `json:"scopes,omitempty"`
 	External           map[string]interface{} `json:"external,omitempty"`
 	ExternalResolution map[string]interface{} `json:"external_resolution,omitempty"`

--- a/nullplatform/resource_link_specification.go
+++ b/nullplatform/resource_link_specification.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -20,12 +21,18 @@ func resourceLinkSpecification() *schema.Resource {
 
 		// Recompute the BOM attributes (last_snapshot_id, action_specifications)
 		// when the spec's content changes, so a package pinning them can't hit an
-		// "inconsistent final plan" on update.
-		CustomizeDiff: specBOMCustomizeDiff(
-			"name", "slug", "unique", "specification_id", "visible_to",
-			"dimensions", "assignable_to", "attributes", "use_default_actions",
-			"use_default_naming", "scopes", "external", "external_resolution",
-			"selectors",
+		// "inconsistent final plan" on update. use_managed_actions is content
+		// too: flipping it re-stamps the generated actions. The second check
+		// mirrors the API's own guard so `use_managed_actions` without
+		// `use_default_actions` is refused at plan time, not as a 400 mid-apply.
+		CustomizeDiff: customdiff.All(
+			specBOMCustomizeDiff(
+				"name", "slug", "unique", "specification_id", "visible_to",
+				"dimensions", "assignable_to", "attributes", "use_default_actions",
+				"use_default_naming", "use_managed_actions", "scopes", "external",
+				"external_resolution", "selectors",
+			),
+			validateManagedRequiresDefaultActions,
 		),
 
 		Importer: &schema.ResourceImporter{
@@ -111,6 +118,13 @@ func resourceLinkSpecification() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Indicates whether the entry point of the link specification actions is derived from the default naming convention (`<service-slug>/link/<action-slug>`). Left to the API default when not set",
+			},
+			"use_managed_actions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				Description: "Indicates whether the CRUD verbs on instances of this specification run through the generated actions instead of writing directly: a PATCH mints the `update` action, a DELETE mints `delete`, and `status = \"archived\"` mints `archive`. " +
+					"Requires `use_default_actions` — a specification that authors its own actions has none to stamp as managed. Left to the API default (false) when not set",
 			},
 			"scopes": {
 				Type:             schema.TypeString,
@@ -217,6 +231,7 @@ func CreateLinkSpecification(_ context.Context, d *schema.ResourceData, m interf
 		Selectors:         &selectors,
 		UseDefaultActions: configuredBool(d, "use_default_actions"),
 		UseDefaultNaming:  configuredBool(d, "use_default_naming"),
+		UseManagedActions: configuredBool(d, "use_managed_actions"),
 		Scopes:            scopes,
 	}
 
@@ -268,6 +283,11 @@ func ReadLinkSpecification(_ context.Context, d *schema.ResourceData, m interfac
 	}
 	if spec.UseDefaultNaming != nil {
 		if err := d.Set("use_default_naming", *spec.UseDefaultNaming); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if spec.UseManagedActions != nil {
+		if err := d.Set("use_managed_actions", *spec.UseManagedActions); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -331,16 +351,20 @@ func ReadLinkSpecification(_ context.Context, d *schema.ResourceData, m interfac
 		}
 	}
 
-	selectors := []map[string]interface{}{
-		{
-			"category":     spec.Selectors.Category,
-			"imported":     spec.Selectors.Imported,
-			"provider":     spec.Selectors.Provider,
-			"sub_category": spec.Selectors.SubCategory,
-		},
-	}
-	if err := d.Set("selectors", selectors); err != nil {
-		return diag.FromErr(err)
+	// A response without `selectors` must not crash the plugin — the data
+	// source already guards this dereference, the resource did not.
+	if spec.Selectors != nil {
+		selectors := []map[string]interface{}{
+			{
+				"category":     spec.Selectors.Category,
+				"imported":     spec.Selectors.Imported,
+				"provider":     spec.Selectors.Provider,
+				"sub_category": spec.Selectors.SubCategory,
+			},
+		}
+		if err := d.Set("selectors", selectors); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil
@@ -365,6 +389,7 @@ func UpdateLinkSpecification(ctx context.Context, d *schema.ResourceData, m inte
 	// and turn the flag off on unrelated updates.
 	spec.UseDefaultActions = configuredBool(d, "use_default_actions")
 	spec.UseDefaultNaming = configuredBool(d, "use_default_naming")
+	spec.UseManagedActions = configuredBool(d, "use_managed_actions")
 
 	if d.HasChange("visible_to") {
 		if v, ok := d.GetOk("visible_to"); ok {

--- a/nullplatform/resource_service_specification.go
+++ b/nullplatform/resource_service_specification.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -20,11 +21,17 @@ func resourceServiceSpecification() *schema.Resource {
 
 		// Recompute the BOM attributes (last_snapshot_id, action_specifications)
 		// when the spec's content changes, so a package pinning them can't hit an
-		// "inconsistent final plan" on update.
-		CustomizeDiff: specBOMCustomizeDiff(
-			"name", "description", "slug", "visible_to", "dimensions",
-			"assignable_to", "type", "attributes", "use_default_actions",
-			"use_default_naming", "scopes", "selectors",
+		// "inconsistent final plan" on update. use_managed_actions is content
+		// too: flipping it re-stamps the generated actions. The second check
+		// mirrors the API's own guard so `use_managed_actions` without
+		// `use_default_actions` is refused at plan time, not as a 400 mid-apply.
+		CustomizeDiff: customdiff.All(
+			specBOMCustomizeDiff(
+				"name", "description", "slug", "visible_to", "dimensions",
+				"assignable_to", "type", "attributes", "use_default_actions",
+				"use_default_naming", "use_managed_actions", "scopes", "selectors",
+			),
+			validateManagedRequiresDefaultActions,
 		),
 
 		Importer: &schema.ResourceImporter{
@@ -111,6 +118,13 @@ func resourceServiceSpecification() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Indicates whether the entry point of the service specification actions is derived from the default naming convention based on the service and action slugs. Left to the API default when not set",
+			},
+			"use_managed_actions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				Description: "Indicates whether the CRUD verbs on instances of this specification run through the generated actions instead of writing directly: a PATCH mints the `update` action, a DELETE mints `delete`, and `status = \"archived\"` mints `archive`. " +
+					"Requires `use_default_actions` — a specification that authors its own actions has none to stamp as managed. Left to the API default (false) when not set",
 			},
 			"scopes": {
 				Type:             schema.TypeString,
@@ -203,6 +217,7 @@ func CreateServiceSpecification(_ context.Context, d *schema.ResourceData, m int
 		Selectors:         &selectors,
 		UseDefaultActions: configuredBool(d, "use_default_actions"),
 		UseDefaultNaming:  configuredBool(d, "use_default_naming"),
+		UseManagedActions: configuredBool(d, "use_managed_actions"),
 		Scopes:            scopes,
 	}
 
@@ -259,6 +274,11 @@ func ReadServiceSpecification(_ context.Context, d *schema.ResourceData, m inter
 			return diag.FromErr(err)
 		}
 	}
+	if spec.UseManagedActions != nil {
+		if err := d.Set("use_managed_actions", *spec.UseManagedActions); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
 	dimensionsJSON, err := json.Marshal(spec.Dimensions)
 	if err != nil {
@@ -291,16 +311,20 @@ func ReadServiceSpecification(_ context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
-	selectors := []map[string]interface{}{
-		{
-			"category":     spec.Selectors.Category,
-			"imported":     spec.Selectors.Imported,
-			"provider":     spec.Selectors.Provider,
-			"sub_category": spec.Selectors.SubCategory,
-		},
-	}
-	if err := d.Set("selectors", selectors); err != nil {
-		return diag.FromErr(err)
+	// A response without `selectors` must not crash the plugin — the data
+	// source already guards this dereference, the resource did not.
+	if spec.Selectors != nil {
+		selectors := []map[string]interface{}{
+			{
+				"category":     spec.Selectors.Category,
+				"imported":     spec.Selectors.Imported,
+				"provider":     spec.Selectors.Provider,
+				"sub_category": spec.Selectors.SubCategory,
+			},
+		}
+		if err := d.Set("selectors", selectors); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil
@@ -319,6 +343,7 @@ func UpdateServiceSpecification(ctx context.Context, d *schema.ResourceData, m i
 	// and turn the flag off on unrelated updates.
 	spec.UseDefaultActions = configuredBool(d, "use_default_actions")
 	spec.UseDefaultNaming = configuredBool(d, "use_default_naming")
+	spec.UseManagedActions = configuredBool(d, "use_managed_actions")
 
 	if d.HasChange("name") {
 		spec.Name = d.Get("name").(string)

--- a/nullplatform/service_specification.go
+++ b/nullplatform/service_specification.go
@@ -36,6 +36,7 @@ type ServiceSpecification struct {
 	Selectors         *Selectors             `json:"selectors,omitempty"` // Use the new struct
 	UseDefaultActions *bool                  `json:"use_default_actions,omitempty"`
 	UseDefaultNaming  *bool                  `json:"use_default_naming,omitempty"`
+	UseManagedActions *bool                  `json:"use_managed_actions,omitempty"`
 	Scopes            map[string]interface{} `json:"scopes,omitempty"`
 }
 

--- a/nullplatform/specification_flags.go
+++ b/nullplatform/specification_flags.go
@@ -1,0 +1,56 @@
+package nullplatform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// optionalBoolFromRaw is configuredBool (utils.go) for callers that hold a raw
+// cty configuration value instead of *schema.ResourceData — CustomizeDiff is
+// one. Same contract: the configured value, or nil when the configuration says
+// nothing, because a null is the only way to tell "absent" from "false".
+func optionalBoolFromRaw(raw cty.Value, key string) *bool {
+	if raw.IsNull() || !raw.IsKnown() {
+		return nil
+	}
+	if !raw.Type().IsObjectType() || !raw.Type().HasAttribute(key) {
+		return nil
+	}
+	value := raw.GetAttr(key)
+	if value.IsNull() || !value.IsKnown() {
+		return nil
+	}
+	configured := value.True()
+	return &configured
+}
+
+// validateManagedRequiresDefaultActions mirrors the API's own guard
+// (`use_managed_actions` requires `use_default_actions`) so the rejection
+// arrives at plan time instead of as a 400 mid-apply. Like the API's version it
+// fires only when BOTH flags are explicitly configured: an absent value means
+// the platform default applies, and the two defaults (use_managed_actions
+// false, use_default_actions true) cannot combine into a violation.
+func validateManagedRequiresDefaultActions(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	raw := diff.GetRawConfig()
+	return managedRequiresDefaultActions(
+		optionalBoolFromRaw(raw, "use_managed_actions"),
+		optionalBoolFromRaw(raw, "use_default_actions"),
+	)
+}
+
+// managedRequiresDefaultActions holds the rule itself, separately from where the
+// values come from. nil means "not configured".
+func managedRequiresDefaultActions(managed, defaults *bool) error {
+	if managed == nil || defaults == nil {
+		return nil
+	}
+	if *managed && !*defaults {
+		return fmt.Errorf("use_managed_actions requires use_default_actions: managed CRUD runs " +
+			"through the generated actions, and a specification that authors its own actions has " +
+			"none to run. Set use_default_actions to true, or leave use_managed_actions off")
+	}
+	return nil
+}

--- a/nullplatform/specification_flags_test.go
+++ b/nullplatform/specification_flags_test.go
@@ -1,0 +1,267 @@
+package nullplatform
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// rawConfigFor builds the cty configuration object Terraform core would send:
+// every attribute of the resource present, null unless the test set it. The SDK
+// exposes no setter for it, so tests attach it to the diff by hand.
+func rawConfigFor(t *testing.T, resource *schema.Resource, config map[string]any) cty.Value {
+	t.Helper()
+	implied := schema.InternalMap(resource.Schema).CoreConfigSchema().ImpliedType()
+	values := map[string]cty.Value{}
+	for name, attrType := range implied.AttributeTypes() {
+		raw, set := config[name]
+		if !set {
+			values[name] = cty.NullVal(attrType)
+			continue
+		}
+		switch typed := raw.(type) {
+		case bool:
+			values[name] = cty.BoolVal(typed)
+		case string:
+			values[name] = cty.StringVal(typed)
+		default:
+			values[name] = cty.NullVal(attrType)
+		}
+	}
+	return cty.ObjectVal(values)
+}
+
+func specificationData(t *testing.T, resource *schema.Resource, config map[string]any) *schema.ResourceData {
+	t.Helper()
+	diff, err := resource.Diff(context.Background(), nil, terraform.NewResourceConfigRaw(config), nil)
+	if err != nil {
+		t.Fatalf("computing the diff: %v", err)
+	}
+	if diff == nil {
+		diff = &terraform.InstanceDiff{}
+	}
+	diff.RawConfig = rawConfigFor(t, resource, config)
+
+	d, err := schema.InternalMap(resource.Schema).Data(nil, diff)
+	if err != nil {
+		t.Fatalf("building resource data: %v", err)
+	}
+	return d
+}
+
+// The regression that motivated this change: the provider declared
+// `Default: false` while the API defaults the flag to `true`, so a configuration
+// that never mentioned the attribute planned `true -> false` on every plan — and
+// the apply could not settle it, because `omitempty` dropped the false from the
+// request body.
+func TestSpecificationFlags_OmittedFlagsPlanClean(t *testing.T) {
+	for name, resource := range map[string]*schema.Resource{
+		"service": resourceServiceSpecification(),
+		"link":    resourceLinkSpecification(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			state := &terraform.InstanceState{
+				ID: "spec-1",
+				Attributes: map[string]string{
+					"id":                  "spec-1",
+					"name":                "redis",
+					"use_default_actions": "true",
+					"use_default_naming":  "true",
+					"use_managed_actions": "false",
+				},
+			}
+
+			diff, err := resource.Diff(context.Background(), state,
+				terraform.NewResourceConfigRaw(map[string]any{"name": "redis"}), nil)
+			if err != nil {
+				t.Fatalf("computing the diff: %v", err)
+			}
+			if diff == nil || diff.Empty() {
+				return
+			}
+			for _, key := range []string{"use_default_actions", "use_default_naming", "use_managed_actions"} {
+				if attr, planned := diff.Attributes[key]; planned {
+					t.Errorf("planned %s %q -> %q for a configuration that never mentions it", key, attr.Old, attr.New)
+				}
+			}
+		})
+	}
+}
+
+// The other half: an explicit value has to reach the wire. `false` was the one
+// that could not, which is what made `use_default_actions = false` impossible to
+// express through Terraform.
+func TestSpecificationFlags_ExplicitValuesAreTransmitted(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config map[string]any
+		want   map[string]any
+	}{
+		{
+			name:   "explicit false is sent, not dropped by omitempty",
+			config: map[string]any{"name": "redis", "use_default_actions": false},
+			want:   map[string]any{"use_default_actions": false},
+		},
+		{
+			name:   "managed opt-in is sent",
+			config: map[string]any{"name": "redis", "use_default_actions": true, "use_managed_actions": true},
+			want:   map[string]any{"use_default_actions": true, "use_managed_actions": true},
+		},
+		{
+			name:   "naming opt-out is sent",
+			config: map[string]any{"name": "redis", "use_default_naming": false},
+			want:   map[string]any{"use_default_naming": false},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := createdSpecificationBody(t, tc.config)
+			for key, want := range tc.want {
+				got, present := body[key]
+				if !present {
+					t.Errorf("%s never reached the request body: %v", key, body)
+					continue
+				}
+				if got != want {
+					t.Errorf("%s = %v, want %v", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+// A flag the configuration does not mention stays off the request entirely, so
+// the API applies its own default instead of the provider guessing at it.
+func TestSpecificationFlags_UnsetFlagsAreNotSent(t *testing.T) {
+	body := createdSpecificationBody(t, map[string]any{"name": "redis"})
+
+	for _, key := range []string{"use_default_actions", "use_default_naming", "use_managed_actions"} {
+		if _, present := body[key]; present {
+			t.Errorf("%s was sent although the configuration never set it: %v", key, body)
+		}
+	}
+}
+
+func createdSpecificationBody(t *testing.T, config map[string]any) map[string]any {
+	t.Helper()
+	var body map[string]any
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "spec-1", "name": "redis"})
+	}))
+	defer server.Close()
+
+	resource := resourceServiceSpecification()
+	d := specificationData(t, resource, config)
+
+	if diags := CreateServiceSpecification(context.Background(), d, newTestClient(server)); diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags)
+	}
+	return body
+}
+
+// The API rejects managed CRUD on a specification that authors its own actions.
+// Mirroring it turns a mid-apply 400 into a plan-time error — and, like the
+// API's own guard, it fires only when BOTH flags are explicitly configured: the
+// two defaults (managed false, defaults true) cannot combine into a violation,
+// so an absent flag must not be assumed either way.
+func TestManagedRequiresDefaultActions(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		managed   *bool
+		defaults  *bool
+		wantError bool
+	}{
+		{name: "managed on, defaults off", managed: boolPtr(true), defaults: boolPtr(false), wantError: true},
+		{name: "managed on, defaults on", managed: boolPtr(true), defaults: boolPtr(true)},
+		{name: "managed on, defaults unset", managed: boolPtr(true), defaults: nil},
+		{name: "managed unset, defaults off", managed: nil, defaults: boolPtr(false)},
+		{name: "managed off, defaults off", managed: boolPtr(false), defaults: boolPtr(false)},
+		{name: "both unset", managed: nil, defaults: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := managedRequiresDefaultActions(tc.managed, tc.defaults)
+			if tc.wantError && err == nil {
+				t.Error("expected the combination to be refused")
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("unexpected refusal: %v", err)
+			}
+		})
+	}
+}
+
+// Both specification resources wire the guard into their plan.
+func TestSpecificationResources_WireTheManagedGuard(t *testing.T) {
+	for name, resource := range map[string]*schema.Resource{
+		"service": resourceServiceSpecification(),
+		"link":    resourceLinkSpecification(),
+	} {
+		if resource.CustomizeDiff == nil {
+			t.Errorf("%s specification does not validate the flag combination at plan time", name)
+		}
+	}
+}
+
+func TestOptionalBoolFromRaw_DistinguishesUnsetFromFalse(t *testing.T) {
+	object := func(value cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{"use_default_actions": value})
+	}
+
+	for _, tc := range []struct {
+		name string
+		raw  cty.Value
+		want *bool
+	}{
+		{name: "explicit false", raw: object(cty.False), want: boolPtr(false)},
+		{name: "explicit true", raw: object(cty.True), want: boolPtr(true)},
+		{name: "null attribute", raw: object(cty.NullVal(cty.Bool)), want: nil},
+		{name: "unknown attribute", raw: object(cty.UnknownVal(cty.Bool)), want: nil},
+		{name: "null object (import, no config)", raw: cty.NullVal(cty.EmptyObject), want: nil},
+		{name: "attribute absent from the object", raw: cty.EmptyObjectVal, want: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := optionalBoolFromRaw(tc.raw, "use_default_actions")
+			switch {
+			case tc.want == nil && got != nil:
+				t.Errorf("got %v, want nil (unset)", *got)
+			case tc.want != nil && got == nil:
+				t.Errorf("got nil, want %v", *tc.want)
+			case tc.want != nil && *got != *tc.want:
+				t.Errorf("got %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// A specification response without `selectors` used to panic both resource
+// reads — a plugin crash, not an error. The data source already guarded it.
+func TestSpecificationRead_SurvivesAResponseWithoutSelectors(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "spec-1", "name": "redis"})
+	}))
+	defer server.Close()
+
+	serviceData := schema.TestResourceDataRaw(t, resourceServiceSpecification().Schema, map[string]any{"name": "redis"})
+	serviceData.SetId("spec-1")
+	if diags := ReadServiceSpecification(context.Background(), serviceData, newTestClient(server)); diags.HasError() {
+		t.Errorf("service specification read: %v", diags)
+	}
+
+	linkData := schema.TestResourceDataRaw(t, resourceLinkSpecification().Schema, map[string]any{"name": "redis"})
+	linkData.SetId("spec-1")
+	if diags := ReadLinkSpecification(context.Background(), linkData, newTestClient(server)); diags.HasError() {
+		t.Errorf("link specification read: %v", diags)
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Rewritten after #146 landed: main fixed the `use_default_actions`/`use_default_naming` transmission bug with the same tri-state design this PR originally carried (`*bool` + `Optional+Computed` + raw-config presence). This PR now adds only what main lacks, through main's own `configuredBool` idiom.

## What

- **`use_managed_actions`** on `nullplatform_service_specification` and `nullplatform_link_specification` (and the service-spec data source). This is the flag that makes a PATCH mint `update`, a DELETE mint `delete`, and `status = "archived"` mint `archive` — without it a Terraform-managed specification cannot opt into managed archive (#147).
- Same tri-state contract as the two flags #146 fixed: a configured value always travels, an omitted flag sends nothing and tracks the API default (`false` — turning it on changes what a verb does, so it is an explicit opt-in).
- **Plan-time guard**: the API rejects `use_managed_actions = true` with `use_default_actions = false` (managed CRUD runs through the generated actions; a spec that authors its own has none to stamp). Mirrored in `CustomizeDiff` — composed with the BOM recompute via `customdiff.All`, and `use_managed_actions` joins the BOM content fields since flipping it re-stamps the generated actions. Like the API's guard, it fires only when both flags are explicitly configured.
- **Latent panic fix**: both specification resource reads dereferenced `spec.Selectors` unguarded — a response without `selectors` crashed the plugin. The data source already guarded it.

## Tests

`specification_flags_test.go`: omitted flags plan clean, explicit values reach the wire (incl. `false`), unset flags stay off the request, the guard matrix (6 combinations), raw-config tri-state edges (null object / unknown / absent attribute), both resources wire the guard, and the no-selectors read survives. All pass alongside #146's own serialization tests.

Merge order: this before #147 (archive integration reads the flag).