### PR TITLE
fix(package): stable BOM order + no spurious replace on spec update

### DIFF
--- a/docs/resources/package.md
+++ b/docs/resources/package.md
@@ -71,7 +71,7 @@ resource "nullplatform_package" "pinned" {
 - `components` (Block List, Min: 1) Bill of materials: one entry per component, each pinning an exact resource revision. (see [below for nested schema](#nestedblock--components))
 - `name` (String) Human-readable display name.
 - `nrn` (String) The owner NRN of the package. Writes (publishes, patches, delete) are gated on it.
-- `slug` (String) URL-safe identifier, unique per NRN. Together with nrn it is the publish key.
+- `slug` (String) URL-safe identifier, unique per NRN. Together with nrn it is the publish key. Replaces the package only on a real rename (see CustomizeDiff), not when it merely resolves to the same value after apply.
 - `version` (String) Semver of the revision this configuration publishes. Bump it together with `components` changes to publish a new revision; re-applying the same version with the same components is an idempotent no-op.
 
 ### Optional

--- a/nullplatform/resource_link_specification.go
+++ b/nullplatform/resource_link_specification.go
@@ -18,6 +18,16 @@ func resourceLinkSpecification() *schema.Resource {
 		UpdateContext: UpdateLinkSpecification,
 		DeleteContext: DeleteLinkSpecification,
 
+		// Recompute the BOM attributes (last_snapshot_id, action_specifications)
+		// when the spec's content changes, so a package pinning them can't hit an
+		// "inconsistent final plan" on update.
+		CustomizeDiff: specBOMCustomizeDiff(
+			"name", "slug", "unique", "specification_id", "visible_to",
+			"dimensions", "assignable_to", "attributes", "use_default_actions",
+			"use_default_naming", "scopes", "external", "external_resolution",
+			"selectors",
+		),
+
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				d.Set("id", d.Id())

--- a/nullplatform/resource_package.go
+++ b/nullplatform/resource_package.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -28,6 +29,17 @@ func resourcePackage() *schema.Resource {
 			},
 		},
 
+		// A package is anchored to its spec (1 spec = 1 package), not to its slug.
+		// A slug that only goes "unknown" at plan — e.g. derived from a spec whose
+		// computed BOM fields recompute on update — must NOT force a replace; it
+		// resolves to the same value after apply. Force a new package only on a
+		// genuine rename: both old and new known, and different.
+		CustomizeDiff: customdiff.ForceNewIfChange("slug", func(ctx context.Context, old, new, meta interface{}) bool {
+			o, _ := old.(string)
+			n, _ := new.(string)
+			return o != "" && n != "" && o != n
+		}),
+
 		Schema: map[string]*schema.Schema{
 			"nrn": {
 				Type:        schema.TypeString,
@@ -38,8 +50,9 @@ func resourcePackage() *schema.Resource {
 			"slug": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "URL-safe identifier, unique per NRN. Together with nrn it is the publish key.",
+				Description: "URL-safe identifier, unique per NRN. Together with nrn it is the publish key. " +
+					"Replaces the package only on a real rename (see CustomizeDiff), not when it merely " +
+					"resolves to the same value after apply.",
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/nullplatform/resource_service_specification.go
+++ b/nullplatform/resource_service_specification.go
@@ -18,6 +18,15 @@ func resourceServiceSpecification() *schema.Resource {
 		UpdateContext: UpdateServiceSpecification,
 		DeleteContext: DeleteServiceSpecification,
 
+		// Recompute the BOM attributes (last_snapshot_id, action_specifications)
+		// when the spec's content changes, so a package pinning them can't hit an
+		// "inconsistent final plan" on update.
+		CustomizeDiff: specBOMCustomizeDiff(
+			"name", "description", "slug", "visible_to", "dimensions",
+			"assignable_to", "type", "attributes", "use_default_actions",
+			"use_default_naming", "scopes", "selectors",
+		),
+
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				d.Set("id", d.Id())

--- a/nullplatform/spec_bom.go
+++ b/nullplatform/spec_bom.go
@@ -1,6 +1,9 @@
 package nullplatform
 
 import (
+	"context"
+	"sort"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -36,9 +39,19 @@ func actionSpecificationsComputedSchema() *schema.Schema {
 // `action_specifications` computed list, resolving each action's newest
 // snapshot id (best-effort — a missing snapshot yields an empty string rather
 // than failing the read).
+//
+// The list is sorted by slug so its order is STABLE across reads and applies.
+// A slug (create-/update-/delete-<spec>) is a stable identity even when the
+// underlying action is re-created with a new id on a spec update, so a package
+// BOM that pins these components as an ordered list keeps a consistent order
+// and Terraform's positional tracking never sees a component "move".
 func actionSpecsToComputedList(nullOps NullOps, actions []*ActionSpecification) []map[string]interface{} {
-	out := make([]map[string]interface{}, 0, len(actions))
-	for _, a := range actions {
+	sorted := make([]*ActionSpecification, len(actions))
+	copy(sorted, actions)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Slug < sorted[j].Slug })
+
+	out := make([]map[string]interface{}, 0, len(sorted))
+	for _, a := range sorted {
 		snapshotID, _ := nullOps.GetLatestSnapshotID("action_specification", a.Id)
 		out = append(out, map[string]interface{}{
 			"id":               a.Id,
@@ -48,4 +61,37 @@ func actionSpecsToComputedList(nullOps NullOps, actions []*ActionSpecification) 
 		})
 	}
 	return out
+}
+
+// specBOMCustomizeDiff forces the computed BOM attributes (last_snapshot_id and
+// action_specifications) to recompute whenever any of the given content fields
+// change on an existing spec.
+//
+// A spec update mints a NEW snapshot and re-creates its default actions with new
+// ids. Without this, the plan keeps the OLD (known) snapshot/action values while
+// the apply produces the new ones, so any package that pins them into its
+// components list fails at apply with "Provider produced inconsistent final
+// plan". Marking these unknown at plan lets apply resolve the new values
+// consistently. On create (empty Id) everything is already unknown, so this is a
+// no-op there and on plans that don't touch the spec's content.
+func specBOMCustomizeDiff(contentFields ...string) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+		if d.Id() == "" {
+			return nil
+		}
+		changed := false
+		for _, f := range contentFields {
+			if d.HasChange(f) {
+				changed = true
+				break
+			}
+		}
+		if !changed {
+			return nil
+		}
+		if err := d.SetNewComputed("last_snapshot_id"); err != nil {
+			return err
+		}
+		return d.SetNewComputed("action_specifications")
+	}
 }


### PR DESCRIPTION
## What

Fixes the `nullplatform_package` **update** path so that changing a service/link spec and bumping the package `version` publishes a new revision **in a single `apply`** — instead of erroring or replacing the package.

A package is a simple BOM (it pins `resource_id` + `resource_revision_id` per component). The bugs were all in the Terraform update lifecycle, and stacked — each hid the next:

1. **Unstable component order** → `Error: Provider produced inconsistent final plan`. On a spec update the platform returns the default actions in a different order, and the package's ordered `components` list is position-tracked, so `components[3]` flipped identity (`delete` → `update`) between plan and apply.
   → `spec_bom.go` now **sorts `action_specifications` by slug** (a stable identity) before putting them in state.

2. **Computed BOM fields not recomputed on change.** A spec update mints a new snapshot + re-creates its actions, but the plan kept the old (known) ids, so any package pinning them saw a value change at apply.
   → service & link specs get a **`CustomizeDiff`** that `SetNewComputed`s `last_snapshot_id` + `action_specifications` when the spec content changes.

3. **`slug` was `ForceNew`** → spurious full replace. Consumers pass the spec through an `any`-typed input, so once (2) marks the spec's BOM fields unknown, the module's `slug`/`name` derived from it collapse to unknown too — and unknown on a `ForceNew` field forces a **replace**. The destroy+recreate then re-claims the spec and hits the platform's `1 spec = 1 package` rule (`FST_ERR_CONFLICT: spec already claimed`).
   → A package is anchored to its **spec**, not its slug. `slug` is no longer `ForceNew`; `customdiff.ForceNewIfChange` replaces only on a **real rename** (old and new both known and different), never on a merely-unknown slug.

## Verification

Local build via `dev_overrides`, against the live API:

- Fresh spec → publish `0.0.1`.
- Change the schema + bump `0.0.2` → **single `apply`**, package **updated in-place**, same package id, `default_version = 0.0.2`.
- Change again + bump `0.0.3` → single `apply`, in-place, same id, no drift.

Before this change the same sequence failed with `Provider produced inconsistent final plan`, then (once that was fixed) with a package replace → `spec already claimed by package`.

## Not covered here

The platform does not release a spec's claim when a package is deleted, so a package that *does* get replaced/deleted can leave a dangling claim. This PR stops the provider from triggering that replace in the normal update path; the claim-release-on-delete behavior is a separate platform-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
