### PR TITLE
Add provider functions to extract entity ids from an NRN

### DIFF
--- a/docs/functions/nrn_extract_account_id.md
+++ b/docs/functions/nrn_extract_account_id.md
@@ -1,0 +1,31 @@
+---
+page_title: "nrn_extract_account_id function - nullplatform"
+subcategory: ""
+description: |-
+  Extract the account id from an NRN
+---
+
+# Function: nrn_extract_account_id
+
+Given an NRN (Nullplatform Resource Name), returns the id of its `account` component. Returns an error if the NRN does not contain an `account` component.
+
+~> Provider-defined functions require Terraform 1.8 or later.
+
+## Example Usage
+
+```terraform
+locals {
+  # var.namespace_nrn = "organization=1255165411:account=95118862:namespace=1991376853"
+  account_id = provider::nullplatform::nrn_extract_account_id(var.namespace_nrn)
+}
+```
+
+## Signature
+
+```text
+nrn_extract_account_id(nrn string) string
+```
+
+## Arguments
+
+1. `nrn` (String) The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).

--- a/docs/functions/nrn_extract_application_id.md
+++ b/docs/functions/nrn_extract_application_id.md
@@ -1,0 +1,35 @@
+---
+page_title: "nrn_extract_application_id function - nullplatform"
+subcategory: ""
+description: |-
+  Extract the application id from an NRN
+---
+
+# Function: nrn_extract_application_id
+
+Given an NRN (Nullplatform Resource Name), returns the id of its `application` component. Returns an error if the NRN does not contain an `application` component.
+
+~> Provider-defined functions require Terraform 1.8 or later.
+
+## Example Usage
+
+```terraform
+locals {
+  # var.application_nrn = "organization=1:account=2:namespace=3:application=4"
+  application_id = provider::nullplatform::nrn_extract_application_id(var.application_nrn)
+}
+
+data "nullplatform_application" "this" {
+  id = local.application_id
+}
+```
+
+## Signature
+
+```text
+nrn_extract_application_id(nrn string) string
+```
+
+## Arguments
+
+1. `nrn` (String) The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).

--- a/docs/functions/nrn_extract_id.md
+++ b/docs/functions/nrn_extract_id.md
@@ -1,0 +1,37 @@
+---
+page_title: "nrn_extract_id function - nullplatform"
+subcategory: ""
+description: |-
+  Extract an entity id from an NRN
+---
+
+# Function: nrn_extract_id
+
+Given an entity type and an NRN (Nullplatform Resource Name), returns the id of the NRN component for that entity type. Returns an error if the NRN does not contain the requested entity type.
+
+Valid entity types include `organization`, `account`, `namespace`, `application`, and `scope`.
+
+Use this function when the entity type comes from a variable; when it is fixed, the dedicated variants (`nrn_extract_account_id`, `nrn_extract_namespace_id`, etc.) are more direct.
+
+~> Provider-defined functions require Terraform 1.8 or later.
+
+## Example Usage
+
+```terraform
+locals {
+  # var.namespace_nrn = "organization=1255165411:account=95118862:namespace=1991376853"
+  account_id   = provider::nullplatform::nrn_extract_id("account", var.namespace_nrn)
+  namespace_id = provider::nullplatform::nrn_extract_id("namespace", var.namespace_nrn)
+}
+```
+
+## Signature
+
+```text
+nrn_extract_id(entity_type string, nrn string) string
+```
+
+## Arguments
+
+1. `entity_type` (String) The entity type whose id should be extracted (e.g. `account`, `namespace`).
+2. `nrn` (String) The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).

--- a/docs/functions/nrn_extract_namespace_id.md
+++ b/docs/functions/nrn_extract_namespace_id.md
@@ -1,0 +1,31 @@
+---
+page_title: "nrn_extract_namespace_id function - nullplatform"
+subcategory: ""
+description: |-
+  Extract the namespace id from an NRN
+---
+
+# Function: nrn_extract_namespace_id
+
+Given an NRN (Nullplatform Resource Name), returns the id of its `namespace` component. Returns an error if the NRN does not contain a `namespace` component.
+
+~> Provider-defined functions require Terraform 1.8 or later.
+
+## Example Usage
+
+```terraform
+locals {
+  # var.namespace_nrn = "organization=1255165411:account=95118862:namespace=1991376853"
+  namespace_id = provider::nullplatform::nrn_extract_namespace_id(var.namespace_nrn)
+}
+```
+
+## Signature
+
+```text
+nrn_extract_namespace_id(nrn string) string
+```
+
+## Arguments
+
+1. `nrn` (String) The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).

--- a/docs/functions/nrn_extract_organization_id.md
+++ b/docs/functions/nrn_extract_organization_id.md
@@ -1,0 +1,31 @@
+---
+page_title: "nrn_extract_organization_id function - nullplatform"
+subcategory: ""
+description: |-
+  Extract the organization id from an NRN
+---
+
+# Function: nrn_extract_organization_id
+
+Given an NRN (Nullplatform Resource Name), returns the id of its `organization` component. Returns an error if the NRN does not contain an `organization` component.
+
+~> Provider-defined functions require Terraform 1.8 or later.
+
+## Example Usage
+
+```terraform
+locals {
+  # var.nrn = "organization=1255165411:account=95118862"
+  organization_id = provider::nullplatform::nrn_extract_organization_id(var.nrn)
+}
+```
+
+## Signature
+
+```text
+nrn_extract_organization_id(nrn string) string
+```
+
+## Arguments
+
+1. `nrn` (String) The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).

--- a/docs/functions/nrn_extract_scope_id.md
+++ b/docs/functions/nrn_extract_scope_id.md
@@ -1,0 +1,31 @@
+---
+page_title: "nrn_extract_scope_id function - nullplatform"
+subcategory: ""
+description: |-
+  Extract the scope id from an NRN
+---
+
+# Function: nrn_extract_scope_id
+
+Given an NRN (Nullplatform Resource Name), returns the id of its `scope` component. Returns an error if the NRN does not contain a `scope` component.
+
+~> Provider-defined functions require Terraform 1.8 or later.
+
+## Example Usage
+
+```terraform
+locals {
+  # var.scope_nrn = "organization=1:account=2:namespace=3:application=4:scope=5"
+  scope_id = provider::nullplatform::nrn_extract_scope_id(var.scope_nrn)
+}
+```
+
+## Signature
+
+```text
+nrn_extract_scope_id(nrn string) string
+```
+
+## Arguments
+
+1. `nrn` (String) The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@ toolchain go1.26.4
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
+	github.com/hashicorp/terraform-plugin-framework v1.13.0
+	github.com/hashicorp/terraform-plugin-go v0.25.0
+	github.com/hashicorp/terraform-plugin-mux v0.17.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
 	github.com/stretchr/testify v1.8.3
 )
@@ -42,7 +45,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.25.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,10 +104,14 @@ github.com/hashicorp/terraform-json v0.22.1 h1:xft84GZR0QzjPVWs4lRUwvTcPnegqlyS7
 github.com/hashicorp/terraform-json v0.22.1/go.mod h1:JbWSQCLFSXFFhg42T7l9iJwdGXBYV8fmmD6o/ML4p3A=
 github.com/hashicorp/terraform-plugin-docs v0.16.0 h1:UmxFr3AScl6Wged84jndJIfFccGyBZn52KtMNsS12dI=
 github.com/hashicorp/terraform-plugin-docs v0.16.0/go.mod h1:M3ZrlKBJAbPMtNOPwHicGi1c+hZUh7/g0ifT/z7TVfA=
+github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
+github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
 github.com/hashicorp/terraform-plugin-go v0.25.0 h1:oi13cx7xXA6QciMcpcFi/rwA974rdTxjqEhXJjbAyks=
 github.com/hashicorp/terraform-plugin-go v0.25.0/go.mod h1:+SYagMYadJP86Kvn+TGeV+ofr/R3g4/If0O5sO96MVw=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
+github.com/hashicorp/terraform-plugin-mux v0.17.0 h1:/J3vv3Ps2ISkbLPiZOLspFcIZ0v5ycUXCEQScudGCCw=
+github.com/hashicorp/terraform-plugin-mux v0.17.0/go.mod h1:yWuM9U1Jg8DryNfvCp+lH70WcYv6D8aooQxxxIzFDsE=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 h1:kJiWGx2kiQVo97Y5IOGR4EMcZ8DtMswHhUuFibsCQQE=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0/go.mod h1:sl/UoabMc37HA6ICVMmGO+/0wofkVIRxf+BMb/dnoIg=
 github.com/hashicorp/terraform-registry-address v0.2.3 h1:2TAiKJ1A3MAkZlH1YI/aTVcLZRu7JseiXNRHbOAyoTI=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,13 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 	"github.com/nullplatform/terraform-provider-nullplatform/nullplatform"
 )
 
@@ -14,8 +20,28 @@ import (
 // Run the docs generation tool, check its repository for more information on how it works and how docs
 // can be customized.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate -provider-name nullplatform
+
+// The provider is served as a mux of two servers: the terraform-plugin-sdk/v2
+// provider (resources and data sources) and a terraform-plugin-framework
+// provider that only contributes provider-defined functions, which SDKv2
+// cannot express.
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: nullplatform.Provider,
-	})
+	ctx := context.Background()
+
+	providers := []func() tfprotov5.ProviderServer{
+		nullplatform.Provider().GRPCProvider,
+		providerserver.NewProtocol5(nullplatform.NewFrameworkProvider()),
+	}
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tf5server.Serve(
+		"registry.terraform.io/nullplatform/nullplatform",
+		muxServer.ProviderServer,
+	); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/nullplatform/framework_provider.go
+++ b/nullplatform/framework_provider.go
@@ -1,0 +1,85 @@
+package nullplatform
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var (
+	_ provider.Provider              = (*frameworkProvider)(nil)
+	_ provider.ProviderWithFunctions = (*frameworkProvider)(nil)
+)
+
+// frameworkProvider is a terraform-plugin-framework provider that only serves
+// provider-defined functions. It is muxed with the terraform-plugin-sdk/v2
+// provider in main.go: resources and data sources stay on the SDKv2 provider,
+// while functions (which SDKv2 cannot express) live here.
+type frameworkProvider struct{}
+
+func NewFrameworkProvider() provider.Provider {
+	return &frameworkProvider{}
+}
+
+func (p *frameworkProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "nullplatform"
+}
+
+// Schema mirrors the SDKv2 provider schema attribute by attribute (types,
+// optional/sensitive flags, descriptions, and deprecations). The mux server
+// requires every muxed provider to expose an identical provider configuration
+// schema; TestMuxServer_ProviderSchemasAreCompatible guards this.
+func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			API_KEY: schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Nullplatform API KEY. Can also be set with the `NULLPLATFORM_API_KEY` environment variable.",
+			},
+			HOST: schema.StringAttribute{
+				Optional:    true,
+				Description: "Nullplatform HOST. Can also be set with the `NULLPLATFORM_HOST` environment variable. If omitted, the default value is `api.nullplatform.com`",
+			},
+			NP_API_KEY: schema.StringAttribute{
+				Optional:           true,
+				Sensitive:          true,
+				Description:        "Nullplatform API KEY. Can also be set with the `NP_API_KEY` environment variable.",
+				DeprecationMessage: "The 'np_apikey' attribute is deprecated and will be removed in a future version. Please use 'api_key' instead.",
+			},
+			NP_API_HOST: schema.StringAttribute{
+				Optional:           true,
+				Description:        "Nullplatform API HOSTNAME. Can also be set with the `NP_API_HOST` environment variable. If omitted, the default value is `api.nullplatform.com`",
+				DeprecationMessage: "The 'np_api_host' attribute is deprecated and will be removed in a future version. Please use 'host' instead.",
+			},
+		},
+	}
+}
+
+// Configure is a no-op: the functions served by this provider are pure NRN
+// string manipulation and never call the API, so no client is needed.
+func (p *frameworkProvider) Configure(_ context.Context, _ provider.ConfigureRequest, _ *provider.ConfigureResponse) {
+}
+
+func (p *frameworkProvider) Resources(_ context.Context) []func() resource.Resource {
+	return nil
+}
+
+func (p *frameworkProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return nil
+}
+
+func (p *frameworkProvider) Functions(_ context.Context) []func() function.Function {
+	return []func() function.Function{
+		NewExtractIDFunction,
+		NewExtractOrganizationIDFunction,
+		NewExtractAccountIDFunction,
+		NewExtractNamespaceIDFunction,
+		NewExtractApplicationIDFunction,
+		NewExtractScopeIDFunction,
+	}
+}

--- a/nullplatform/framework_provider_test.go
+++ b/nullplatform/framework_provider_test.go
@@ -1,0 +1,70 @@
+package nullplatform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+)
+
+// The mux server requires the SDKv2 provider and the framework provider to
+// expose identical provider configuration schemas. Any drift between
+// provider.go and framework_provider.go (a new attribute, a reworded
+// description, a changed deprecation message) breaks the muxed server at
+// runtime, so this test exercises the same combination main.go serves.
+func TestMuxServer_ProviderSchemasAreCompatible(t *testing.T) {
+	ctx := context.Background()
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx,
+		Provider().GRPCProvider,
+		providerserver.NewProtocol5(NewFrameworkProvider()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create mux server: %v", err)
+	}
+
+	resp, err := muxServer.ProviderServer().GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema failed: %v", err)
+	}
+
+	for _, diagnostic := range resp.Diagnostics {
+		if diagnostic.Severity == tfprotov5.DiagnosticSeverityError {
+			t.Errorf("provider schemas are not mux-compatible: %s: %s", diagnostic.Summary, diagnostic.Detail)
+		}
+	}
+}
+
+func TestMuxServer_ServesExtractFunctions(t *testing.T) {
+	ctx := context.Background()
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx,
+		Provider().GRPCProvider,
+		providerserver.NewProtocol5(NewFrameworkProvider()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create mux server: %v", err)
+	}
+
+	resp, err := muxServer.ProviderServer().GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema failed: %v", err)
+	}
+
+	wantFunctions := []string{
+		"nrn_extract_id",
+		"nrn_extract_organization_id",
+		"nrn_extract_account_id",
+		"nrn_extract_namespace_id",
+		"nrn_extract_application_id",
+		"nrn_extract_scope_id",
+	}
+
+	for _, name := range wantFunctions {
+		if _, ok := resp.Functions[name]; !ok {
+			t.Errorf("function %q is not served by the muxed provider", name)
+		}
+	}
+}

--- a/nullplatform/function_extract_id.go
+++ b/nullplatform/function_extract_id.go
@@ -1,0 +1,151 @@
+package nullplatform
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+// extractIDFromNRN returns the id of the given entity type from an NRN of the
+// form "organization=1:account=2:namespace=3:application=4:scope=5".
+func extractIDFromNRN(nrn, entityType string) (string, error) {
+	entityType = strings.ToLower(strings.TrimSpace(entityType))
+	if entityType == "" {
+		return "", fmt.Errorf("entity type must not be empty")
+	}
+
+	nrn = strings.TrimSpace(nrn)
+	if nrn == "" {
+		return "", fmt.Errorf("NRN must not be empty")
+	}
+
+	var contained []string
+	for _, segment := range strings.Split(nrn, ":") {
+		key, value, found := strings.Cut(segment, "=")
+		if !found || key == "" || value == "" {
+			return "", fmt.Errorf("invalid NRN %q: segment %q is not in \"<entity>=<id>\" format", nrn, segment)
+		}
+		if key == entityType {
+			return value, nil
+		}
+		contained = append(contained, key)
+	}
+
+	return "", fmt.Errorf("NRN %q does not contain an id for entity type %q (it contains: %s)", nrn, entityType, strings.Join(contained, ", "))
+}
+
+var _ function.Function = (*extractIDFunction)(nil)
+
+// extractIDFunction implements provider::nullplatform::nrn_extract_id, taking
+// the entity type as its first argument for cases where the type comes from a
+// variable. The nrn_extract_<entity>_id variants cover the common fixed-type
+// case.
+type extractIDFunction struct{}
+
+func NewExtractIDFunction() function.Function {
+	return &extractIDFunction{}
+}
+
+func (f *extractIDFunction) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "nrn_extract_id"
+}
+
+func (f *extractIDFunction) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:     "Extract an entity id from an NRN",
+		Description: "Given an entity type and an NRN (Nullplatform Resource Name), returns the id of the NRN component for that entity type. Returns an error if the NRN does not contain the requested entity type. Valid entity types include `organization`, `account`, `namespace`, `application`, and `scope`.",
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:        "entity_type",
+				Description: "The entity type whose id should be extracted (e.g. `account`, `namespace`).",
+			},
+			function.StringParameter{
+				Name:        "nrn",
+				Description: "The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f *extractIDFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var entityType, nrn string
+
+	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &entityType, &nrn))
+	if resp.Error != nil {
+		return
+	}
+
+	id, err := extractIDFromNRN(nrn, entityType)
+	if err != nil {
+		resp.Error = function.ConcatFuncErrors(resp.Error, function.NewArgumentFuncError(1, err.Error()))
+		return
+	}
+
+	resp.Error = function.ConcatFuncErrors(resp.Error, resp.Result.Set(ctx, id))
+}
+
+var _ function.Function = (*extractEntityIDFunction)(nil)
+
+// extractEntityIDFunction implements the nrn_extract_<entity>_id family of
+// functions; each instance is bound to a single entity type.
+type extractEntityIDFunction struct {
+	entityType string
+}
+
+func NewExtractOrganizationIDFunction() function.Function {
+	return &extractEntityIDFunction{entityType: "organization"}
+}
+
+func NewExtractAccountIDFunction() function.Function {
+	return &extractEntityIDFunction{entityType: "account"}
+}
+
+func NewExtractNamespaceIDFunction() function.Function {
+	return &extractEntityIDFunction{entityType: "namespace"}
+}
+
+func NewExtractApplicationIDFunction() function.Function {
+	return &extractEntityIDFunction{entityType: "application"}
+}
+
+func NewExtractScopeIDFunction() function.Function {
+	return &extractEntityIDFunction{entityType: "scope"}
+}
+
+func (f *extractEntityIDFunction) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = fmt.Sprintf("nrn_extract_%s_id", f.entityType)
+}
+
+func (f *extractEntityIDFunction) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:     fmt.Sprintf("Extract the %s id from an NRN", f.entityType),
+		Description: fmt.Sprintf("Given an NRN (Nullplatform Resource Name), returns the id of its `%s` component. Returns an error if the NRN does not contain a `%s` component.", f.entityType, f.entityType),
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:        "nrn",
+				Description: "The NRN to extract the id from (e.g. `organization=1:account=2:namespace=3`).",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f *extractEntityIDFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var nrn string
+
+	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &nrn))
+	if resp.Error != nil {
+		return
+	}
+
+	id, err := extractIDFromNRN(nrn, f.entityType)
+	if err != nil {
+		resp.Error = function.ConcatFuncErrors(resp.Error, function.NewArgumentFuncError(0, err.Error()))
+		return
+	}
+
+	resp.Error = function.ConcatFuncErrors(resp.Error, resp.Result.Set(ctx, id))
+}

--- a/nullplatform/function_extract_id_test.go
+++ b/nullplatform/function_extract_id_test.go
@@ -1,0 +1,144 @@
+package nullplatform
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const testNRN = "organization=1255165411:account=95118862:namespace=1991376853:application=1152869225:scope=272433493"
+
+func TestExtractIDFromNRN(t *testing.T) {
+	tests := []struct {
+		name       string
+		nrn        string
+		entityType string
+		want       string
+		wantErr    string
+	}{
+		{name: "organization", nrn: testNRN, entityType: "organization", want: "1255165411"},
+		{name: "account", nrn: testNRN, entityType: "account", want: "95118862"},
+		{name: "namespace", nrn: testNRN, entityType: "namespace", want: "1991376853"},
+		{name: "application", nrn: testNRN, entityType: "application", want: "1152869225"},
+		{name: "scope", nrn: testNRN, entityType: "scope", want: "272433493"},
+		{name: "partial nrn", nrn: "organization=1:account=2", entityType: "account", want: "2"},
+		{name: "entity type is case-insensitive", nrn: testNRN, entityType: "Account", want: "95118862"},
+		{name: "surrounding whitespace is tolerated", nrn: "  " + testNRN + "  ", entityType: " account ", want: "95118862"},
+		{name: "missing entity type", nrn: "organization=1:account=2", entityType: "application", wantErr: "does not contain an id"},
+		{name: "empty nrn", nrn: "", entityType: "account", wantErr: "NRN must not be empty"},
+		{name: "empty entity type", nrn: testNRN, entityType: "", wantErr: "entity type must not be empty"},
+		{name: "malformed segment", nrn: "organization=1:account", entityType: "account", wantErr: "not in \"<entity>=<id>\" format"},
+		{name: "empty segment value", nrn: "organization=1:account=", entityType: "account", wantErr: "not in \"<entity>=<id>\" format"},
+		{name: "not an nrn at all", nrn: "hello world", entityType: "account", wantErr: "not in \"<entity>=<id>\" format"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractIDFromNRN(tt.nrn, tt.entityType)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got id %q", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func runFunction(t *testing.T, f function.Function, args []attr.Value) *function.RunResponse {
+	t.Helper()
+
+	resp := &function.RunResponse{
+		Result: function.NewResultData(types.StringUnknown()),
+	}
+	f.Run(context.Background(), function.RunRequest{
+		Arguments: function.NewArgumentsData(args),
+	}, resp)
+
+	return resp
+}
+
+func TestExtractIDFunction_Run(t *testing.T) {
+	resp := runFunction(t, NewExtractIDFunction(), []attr.Value{
+		types.StringValue("account"),
+		types.StringValue(testNRN),
+	})
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	if got, want := resp.Result.Value(), types.StringValue("95118862"); !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestExtractIDFunction_RunErrorsWhenEntityTypeMissing(t *testing.T) {
+	resp := runFunction(t, NewExtractIDFunction(), []attr.Value{
+		types.StringValue("scope"),
+		types.StringValue("organization=1:account=2"),
+	})
+
+	if resp.Error == nil {
+		t.Fatal("expected an error for an NRN without the requested entity type, got none")
+	}
+	if !strings.Contains(resp.Error.Error(), "does not contain an id") {
+		t.Errorf("unexpected error message: %v", resp.Error)
+	}
+}
+
+func TestExtractEntityIDFunctions_Run(t *testing.T) {
+	tests := []struct {
+		newFunc  func() function.Function
+		wantName string
+		want     string
+	}{
+		{NewExtractOrganizationIDFunction, "nrn_extract_organization_id", "1255165411"},
+		{NewExtractAccountIDFunction, "nrn_extract_account_id", "95118862"},
+		{NewExtractNamespaceIDFunction, "nrn_extract_namespace_id", "1991376853"},
+		{NewExtractApplicationIDFunction, "nrn_extract_application_id", "1152869225"},
+		{NewExtractScopeIDFunction, "nrn_extract_scope_id", "272433493"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wantName, func(t *testing.T) {
+			f := tt.newFunc()
+
+			metaResp := &function.MetadataResponse{}
+			f.Metadata(context.Background(), function.MetadataRequest{}, metaResp)
+			if metaResp.Name != tt.wantName {
+				t.Errorf("function name = %q, want %q", metaResp.Name, tt.wantName)
+			}
+
+			resp := runFunction(t, f, []attr.Value{types.StringValue(testNRN)})
+			if resp.Error != nil {
+				t.Fatalf("unexpected error: %v", resp.Error)
+			}
+			if got, want := resp.Result.Value(), types.StringValue(tt.want); !got.Equal(want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestExtractEntityIDFunction_RunErrorsWhenComponentMissing(t *testing.T) {
+	resp := runFunction(t, NewExtractScopeIDFunction(), []attr.Value{
+		types.StringValue("organization=1:account=2"),
+	})
+
+	if resp.Error == nil {
+		t.Fatal("expected an error for an NRN without a scope component, got none")
+	}
+}


### PR DESCRIPTION
Closes #153

## What

Adds six provider-defined functions that extract entity ids from an NRN, removing the need for terraform logic to know the NRN structure:

```terraform
locals {
  # Generic form — for when the entity type comes from a variable
  account_id   = provider::nullplatform::nrn_extract_id("account", var.namespace_nrn)

  # Dedicated variants — entity type baked into the name
  namespace_id = provider::nullplatform::nrn_extract_namespace_id(var.namespace_nrn)
}
```

The full set: `nrn_extract_id(entity_type, nrn)` plus `nrn_extract_organization_id`, `nrn_extract_account_id`, `nrn_extract_namespace_id`, `nrn_extract_application_id`, and `nrn_extract_scope_id` (each taking just the `nrn`). This covers both design alternatives discussed in the issue — the dedicated variants for readability and discoverability, and the generic form for the variable-entity-type scenario. As requested, the functions error (with a Terraform diagnostic pointing at the offending argument) when the NRN does not contain the requested entity type, and also on malformed NRNs.

Two deviations from the issue's sketch: names are `snake_case` (rather than `extractId`), following the Terraform provider-function naming convention, and they carry an `nrn_` prefix so the object they operate on is obvious at the call site.

## How

SDKv2 cannot express provider-defined functions, so this follows HashiCorp's standard pattern for adding functions to an SDKv2 provider:

- A minimal `terraform-plugin-framework` provider (`framework_provider.go`) contributes **only** the functions — all resources and data sources stay on the SDKv2 provider, which is untouched.
- `main.go` serves the two providers combined via `tf5muxserver` (same protocol version 5 as before).
- The framework provider mirrors the SDKv2 provider configuration schema attribute by attribute, which the mux server requires; a dedicated test (`TestMuxServer_ProviderSchemasAreCompatible`) exercises the muxed `GetProviderSchema` so any future drift between the two schemas fails CI instead of breaking the released binary.
- New dependencies are pinned to versions compatible with the existing `terraform-plugin-go v0.25.0`, so no transitive dependency bumps.

The functions are pure string manipulation — they never call the API and don't require provider configuration/credentials.

**Compatibility:** calling the functions requires Terraform >= 1.8 or OpenTofu >= 1.7 (noted in each doc page). Older CLI versions continue to work with all existing resources and data sources; the mux changes nothing about them.

## Docs

The pinned tfplugindocs (v0.16) predates function docs generation but preserves `docs/functions/`, so the six doc pages are hand-written in registry format (verified `go generate ./...` leaves them intact — no toolchain upgrade needed).

## Testing

- Table tests for the NRN parser covering every entity type, partial NRNs, case/whitespace tolerance, missing components, and malformed input.
- Invocation tests for all six functions through the framework's `function.Run` interface, including error paths.
- Mux compatibility tests as described above.
- End-to-end against a real CLI (OpenTofu v1.11.5 with a dev-override of the locally built binary): all six functions return the expected ids from a five-component NRN in `tofu plan` outputs, and a truncated NRN produces the expected `Invalid function argument` error at the call site.
- `go build ./...`, `go vet ./...`, and the full test suite pass.
