### PR TITLE
fix(scope_type): omit unset fields on partial updates

### DIFF
--- a/docs/resources/scope_type.md
+++ b/docs/resources/scope_type.md
@@ -69,8 +69,8 @@ output "db_backup_scope_type" {
 
 ### Required
 
-- `description` (String) Short description of how the scope type works or what it does.
-- `name` (String) The display name shown to developers to identify the scope type.
+- `description` (String) Short description of how the scope type works or what it does. Cannot be empty: an update clearing it would be dropped from the request body and silently leave the stored value in place.
+- `name` (String) The display name shown to developers to identify the scope type. Cannot be empty: an update clearing it would be dropped from the request body and silently leave the stored value in place.
 - `provider_id` (String) The ID of the entity that implements the scope type.
 
 ### Optional

--- a/nullplatform/resource_scope_type.go
+++ b/nullplatform/resource_scope_type.go
@@ -34,9 +34,10 @@ func resourceScopeType() *schema.Resource {
 				Description:  "The type of scope type.",
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The display name shown to developers to identify the scope type.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				Description:  "The display name shown to developers to identify the scope type. Cannot be empty: an update clearing it would be dropped from the request body and silently leave the stored value in place.",
 			},
 			"status": {
 				Type:        schema.TypeString,
@@ -44,9 +45,10 @@ func resourceScopeType() *schema.Resource {
 				Description: "Whether this scope type is enabled to be used. Always set to 'active' on creation.",
 			},
 			"description": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Short description of how the scope type works or what it does.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				Description:  "Short description of how the scope type works or what it does. Cannot be empty: an update clearing it would be dropped from the request body and silently leave the stored value in place.",
 			},
 			"provider_type": {
 				Type:         schema.TypeString,

--- a/nullplatform/scope_type.go
+++ b/nullplatform/scope_type.go
@@ -12,6 +12,11 @@ const (
 	SCOPE_TYPE_PATH = "/scope_type"
 )
 
+// ScopeType doubles as the full CreateScopeType body and the partial
+// PatchScopeType body, which populates only the fields d.HasChange reports:
+// every field must stay omitempty or an update blanks the ones it did not set.
+// Empty is not a legal value for name or description (see the resource's
+// ValidateFunc), so omitempty cannot swallow a deliberate clear.
 type ScopeType struct {
 	Id           int    `json:"id,omitempty"`
 	Nrn          string `json:"nrn,omitempty"`

--- a/nullplatform/scope_type.go
+++ b/nullplatform/scope_type.go
@@ -15,12 +15,12 @@ const (
 type ScopeType struct {
 	Id           int    `json:"id,omitempty"`
 	Nrn          string `json:"nrn,omitempty"`
-	Type         string `json:"type"`
-	Name         string `json:"name"`
-	Status       string `json:"status"`
-	Description  string `json:"description"`
-	ProviderType string `json:"provider_type"`
-	ProviderId   string `json:"provider_id"`
+	Type         string `json:"type,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Description  string `json:"description,omitempty"`
+	ProviderType string `json:"provider_type,omitempty"`
+	ProviderId   string `json:"provider_id,omitempty"`
 }
 
 func (c *NullClient) CreateScopeType(s *ScopeType) (*ScopeType, error) {

--- a/nullplatform/scope_type_test.go
+++ b/nullplatform/scope_type_test.go
@@ -1,61 +1,99 @@
 package nullplatform
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// A partial update must only carry the fields that actually changed. Before the
-// omitempty tags, an update that touched just the description also serialized
-// `"name": ""`, which the API rejects with
+// scopeTypeServer serves a scope type and captures the body of the write
+// request, so a test can assert on the exact payload the provider put on the
+// wire rather than on the struct tags that shaped it.
+func scopeTypeServer(t *testing.T, writeMethod string, captured *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == writeMethod {
+			if err := json.NewDecoder(r.Body).Decode(captured); err != nil {
+				t.Errorf("decoding the %s body: %v", writeMethod, err)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(ScopeType{
+			Id: 1, Nrn: "organization=1:account=2", Type: "custom",
+			Name: "Containers", Status: "active", Description: "new description",
+			ProviderType: "service", ProviderId: "spec-1",
+		})
+	}))
+}
+
+// A partial update must carry only the fields that changed. Before ScopeType's
+// fields were tagged omitempty, an update that touched just the description
+// also serialized `"name": ""`, which the API rejects with
 // `body/name must NOT have fewer than 1 characters`, and blanked provider_id
 // and provider_type on the way.
-func TestScopeType_PartialUpdateOmitsUnsetFields(t *testing.T) {
-	body, err := json.Marshal(&ScopeType{Description: "new description"})
+func TestScopeTypeUpdate_SendsOnlyChangedFields(t *testing.T) {
+	var patched map[string]any
+	server := scopeTypeServer(t, http.MethodPut, &patched)
+	defer server.Close()
+
+	state := &terraform.InstanceState{ID: "1", Attributes: map[string]string{
+		"id": "1", "nrn": "organization=1:account=2", "type": "custom",
+		"name": "Containers", "status": "active", "description": "old description",
+		"provider_type": "service", "provider_id": "spec-1",
+	}}
+	diff, err := resourceScopeType().Diff(context.Background(), state, terraform.NewResourceConfigRaw(map[string]any{
+		"nrn": "organization=1:account=2", "type": "custom",
+		"name": "Containers", "description": "new description",
+		"provider_type": "service", "provider_id": "spec-1",
+	}), nil)
 	if err != nil {
-		t.Fatalf("failed to marshal scope type: %v", err)
+		t.Fatalf("computing the diff: %v", err)
+	}
+	d, err := schema.InternalMap(resourceScopeType().Schema).Data(state, diff)
+	if err != nil {
+		t.Fatalf("building resource data: %v", err)
 	}
 
-	var got map[string]any
-	if err := json.Unmarshal(body, &got); err != nil {
-		t.Fatalf("failed to unmarshal scope type: %v", err)
+	if err := ScopeTypeUpdate(d, newTestClient(server)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if want := map[string]any{"description": "new description"}; len(got) != len(want) {
-		t.Fatalf("partial update body = %s, want only the changed field", body)
-	}
-
-	for _, field := range []string{"name", "type", "status", "provider_id", "provider_type"} {
-		if _, present := got[field]; present {
-			t.Errorf("unset field %q was serialized; it must be omitted on a partial update", field)
-		}
+	want := map[string]any{"description": "new description"}
+	if !reflect.DeepEqual(patched, want) {
+		t.Errorf("partial update body = %v, want %v", patched, want)
 	}
 }
 
-// Create still has to send every field, so omitempty must not drop values that
-// were explicitly set.
-func TestScopeType_CreateKeepsAllSetFields(t *testing.T) {
-	body, err := json.Marshal(&ScopeType{
-		Nrn:          "organization=1:account=2",
-		Type:         "containers",
-		Name:         "Containers",
-		Status:       "active",
-		Description:  "Docker containers on pods",
-		ProviderType: "kubernetes",
-		ProviderId:   "spec-1",
+// Create still has to send every field, so omitempty must not drop values the
+// operator set.
+func TestScopeTypeCreate_SendsEveryField(t *testing.T) {
+	var created map[string]any
+	server := scopeTypeServer(t, http.MethodPost, &created)
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, resourceScopeType().Schema, map[string]any{
+		"nrn": "organization=1:account=2", "type": "custom",
+		"name": "Containers", "description": "Docker containers on pods",
+		"provider_type": "service", "provider_id": "spec-1",
 	})
-	if err != nil {
-		t.Fatalf("failed to marshal scope type: %v", err)
+
+	if err := ScopeTypeCreate(d, newTestClient(server)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var got map[string]any
-	if err := json.Unmarshal(body, &got); err != nil {
-		t.Fatalf("failed to unmarshal scope type: %v", err)
+	want := map[string]any{
+		"nrn": "organization=1:account=2", "type": "custom",
+		"name": "Containers", "status": "active",
+		"description":   "Docker containers on pods",
+		"provider_type": "service", "provider_id": "spec-1",
 	}
-
-	for _, field := range []string{"nrn", "type", "name", "status", "description", "provider_type", "provider_id"} {
-		if _, present := got[field]; !present {
-			t.Errorf("field %q was dropped from the create body: %s", field, body)
-		}
+	if !reflect.DeepEqual(created, want) {
+		t.Errorf("create body = %v, want %v", created, want)
 	}
 }

--- a/nullplatform/scope_type_test.go
+++ b/nullplatform/scope_type_test.go
@@ -1,0 +1,61 @@
+package nullplatform
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// A partial update must only carry the fields that actually changed. Before the
+// omitempty tags, an update that touched just the description also serialized
+// `"name": ""`, which the API rejects with
+// `body/name must NOT have fewer than 1 characters`, and blanked provider_id
+// and provider_type on the way.
+func TestScopeType_PartialUpdateOmitsUnsetFields(t *testing.T) {
+	body, err := json.Marshal(&ScopeType{Description: "new description"})
+	if err != nil {
+		t.Fatalf("failed to marshal scope type: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("failed to unmarshal scope type: %v", err)
+	}
+
+	if want := map[string]any{"description": "new description"}; len(got) != len(want) {
+		t.Fatalf("partial update body = %s, want only the changed field", body)
+	}
+
+	for _, field := range []string{"name", "type", "status", "provider_id", "provider_type"} {
+		if _, present := got[field]; present {
+			t.Errorf("unset field %q was serialized; it must be omitted on a partial update", field)
+		}
+	}
+}
+
+// Create still has to send every field, so omitempty must not drop values that
+// were explicitly set.
+func TestScopeType_CreateKeepsAllSetFields(t *testing.T) {
+	body, err := json.Marshal(&ScopeType{
+		Nrn:          "organization=1:account=2",
+		Type:         "containers",
+		Name:         "Containers",
+		Status:       "active",
+		Description:  "Docker containers on pods",
+		ProviderType: "kubernetes",
+		ProviderId:   "spec-1",
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal scope type: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("failed to unmarshal scope type: %v", err)
+	}
+
+	for _, field := range []string{"nrn", "type", "name", "status", "description", "provider_type", "provider_id"} {
+		if _, present := got[field]; !present {
+			t.Errorf("field %q was dropped from the create body: %s", field, body)
+		}
+	}
+}

--- a/nullplatform/scope_type_test.go
+++ b/nullplatform/scope_type_test.go
@@ -3,9 +3,11 @@ package nullplatform
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -26,32 +28,35 @@ func scopeTypeServer(t *testing.T, writeMethod string, captured *map[string]any)
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(ScopeType{
 			Id: 1, Nrn: "organization=1:account=2", Type: "custom",
-			Name: "Containers", Status: "active", Description: "new description",
+			Name: "Containers", Status: "active", Description: "old description",
 			ProviderType: "service", ProviderId: "spec-1",
 		})
 	}))
 }
 
-// A partial update must carry only the fields that changed. Before ScopeType's
-// fields were tagged omitempty, an update that touched just the description
-// also serialized `"name": ""`, which the API rejects with
-// `body/name must NOT have fewer than 1 characters`, and blanked provider_id
-// and provider_type on the way.
-func TestScopeTypeUpdate_SendsOnlyChangedFields(t *testing.T) {
-	var patched map[string]any
-	server := scopeTypeServer(t, http.MethodPut, &patched)
-	defer server.Close()
-
-	state := &terraform.InstanceState{ID: "1", Attributes: map[string]string{
+func scopeTypeState() map[string]string {
+	return map[string]string{
 		"id": "1", "nrn": "organization=1:account=2", "type": "custom",
 		"name": "Containers", "status": "active", "description": "old description",
 		"provider_type": "service", "provider_id": "spec-1",
-	}}
-	diff, err := resourceScopeType().Diff(context.Background(), state, terraform.NewResourceConfigRaw(map[string]any{
+	}
+}
+
+func scopeTypeConfig(name, description string) map[string]any {
+	return map[string]any{
 		"nrn": "organization=1:account=2", "type": "custom",
-		"name": "Containers", "description": "new description",
+		"name": name, "description": description,
 		"provider_type": "service", "provider_id": "spec-1",
-	}), nil)
+	}
+}
+
+// updateResourceData builds the ResourceData Terraform itself would hand to
+// Update, so d.HasChange reports a real state-versus-config diff instead of a
+// flag the test set by hand.
+func updateResourceData(t *testing.T, config map[string]any) *schema.ResourceData {
+	t.Helper()
+	state := &terraform.InstanceState{ID: "1", Attributes: scopeTypeState()}
+	diff, err := resourceScopeType().Diff(context.Background(), state, terraform.NewResourceConfigRaw(config), nil)
 	if err != nil {
 		t.Fatalf("computing the diff: %v", err)
 	}
@@ -59,14 +64,88 @@ func TestScopeTypeUpdate_SendsOnlyChangedFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("building resource data: %v", err)
 	}
+	return d
+}
 
-	if err := ScopeTypeUpdate(d, newTestClient(server)); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// A partial update must carry only the fields that changed. Before ScopeType's
+// fields were tagged omitempty, every update serialized the fields Update never
+// assigns — type, status, provider_id and provider_type — as empty strings, and
+// one that left the name alone sent `"name": ""`, which the API rejects with
+// `body/name must NOT have fewer than 1 characters`.
+func TestScopeTypeUpdate_SendsOnlyChangedFields(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config map[string]any
+		want   map[string]any
+	}{
+		{
+			name:   "description only",
+			config: scopeTypeConfig("Containers", "new description"),
+			want:   map[string]any{"description": "new description"},
+		},
+		{
+			// name is the field the API refused, and the description-only case
+			// never reaches its branch in ScopeTypeUpdate.
+			name:   "name only",
+			config: scopeTypeConfig("Pods", "old description"),
+			want:   map[string]any{"name": "Pods"},
+		},
+		{
+			name:   "both",
+			config: scopeTypeConfig("Pods", "new description"),
+			want:   map[string]any{"name": "Pods", "description": "new description"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var patched map[string]any
+			server := scopeTypeServer(t, http.MethodPut, &patched)
+			defer server.Close()
+
+			if err := ScopeTypeUpdate(updateResourceData(t, tc.config), newTestClient(server)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(patched, tc.want) {
+				t.Errorf("partial update body = %v, want %v", patched, tc.want)
+			}
+		})
 	}
+}
 
-	want := map[string]any{"description": "new description"}
-	if !reflect.DeepEqual(patched, want) {
-		t.Errorf("partial update body = %v, want %v", patched, want)
+// The API's refusal is contract: the provider has to surface the response body
+// verbatim, because the message is the only thing naming the guard that
+// refused.
+func TestScopeTypeUpdate_SurfacesAPIRefusal(t *testing.T) {
+	const refusal = `{"message":"body/name must NOT have fewer than 1 characters"}`
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, refusal)
+	}))
+	defer server.Close()
+
+	err := ScopeTypeUpdate(updateResourceData(t, scopeTypeConfig("Pods", "old description")), newTestClient(server))
+	if err == nil {
+		t.Fatal("an API refusal must fail the update")
+	}
+	if !strings.Contains(err.Error(), refusal) {
+		t.Errorf("error = %q, want it to carry the API response %q", err, refusal)
+	}
+}
+
+// omitempty cannot tell "unchanged" from "deliberately emptied", so an update
+// clearing name or description would be dropped from the body: the API keeps
+// the old value, Read writes it back, and the plan never converges. Rejecting
+// empty at plan time is what keeps that state unreachable.
+func TestScopeType_RejectsEmptyRequiredStrings(t *testing.T) {
+	for _, field := range []string{"name", "description"} {
+		t.Run(field, func(t *testing.T) {
+			validate := resourceScopeType().Schema[field].ValidateFunc
+			if validate == nil {
+				t.Fatalf("%q must validate, or omitempty can swallow a deliberate clear", field)
+			}
+			if _, errs := validate("", field); len(errs) == 0 {
+				t.Errorf("%q must reject the empty string", field)
+			}
+		})
 	}
 }
 
@@ -77,11 +156,8 @@ func TestScopeTypeCreate_SendsEveryField(t *testing.T) {
 	server := scopeTypeServer(t, http.MethodPost, &created)
 	defer server.Close()
 
-	d := schema.TestResourceDataRaw(t, resourceScopeType().Schema, map[string]any{
-		"nrn": "organization=1:account=2", "type": "custom",
-		"name": "Containers", "description": "Docker containers on pods",
-		"provider_type": "service", "provider_id": "spec-1",
-	})
+	d := schema.TestResourceDataRaw(t, resourceScopeType().Schema,
+		scopeTypeConfig("Containers", "Docker containers on pods"))
 
 	if err := ScopeTypeCreate(d, newTestClient(server)); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -1,4 +1,4 @@
-20.2
+22.8
 # The coverage ratchet: total statement coverage must not fall below this.
 # Raise it when a PR lifts the total; lower it ONLY when deleting covered
 # code, in the same PR, saying so in the commit message.


### PR DESCRIPTION
A `nullplatform_scope_type` update that changes only the description fails:

```
Error: failed to patch scope type resource: status code 400,
{"code":"VALIDATION.REQUEST_SCHEMA","errors":[{"field":"name","issue":"minLength",
"message":"body/name must NOT have fewer than 1 characters"}]}
```

`ScopeTypeUpdate` builds the payload from the fields that changed:

```go
updateScopeType := &ScopeType{}
if d.HasChange("name") { updateScopeType.Name = d.Get("name").(string) }
if d.HasChange("description") { updateScopeType.Description = ... }
```

but the struct had no `omitempty`, so every field `Update` never assigns was
serialized as `""`. The API rejects an empty `name`, which is what surfaces. The
quieter problem is that the same body also sent `type`, `status`, `provider_id`
and `provider_type` as `""` — one validation rule away from unlinking the scope
type from its service specification.

Verified against the API that a PATCH carrying only `description` is accepted
(204), so omitting unchanged fields is the behaviour the endpoint expects.

`ScopeTypeCreate` sets every field explicitly, so it is unaffected; a create
test pins that so `omitempty` cannot silently drop a value on create.

## Behaviour change: empty `name` / `description` now fail at plan time

`omitempty` cannot distinguish "this field is not part of the update" from "the
operator cleared it" — both are the Go zero value. `ScopeTypeUpdate` signals
"unchanged" by leaving a field zero, so an update that cleared the description
would be dropped from the request body: the API keeps the stored value, `Read`
writes that value back, and the plan never converges — an apply that reports
success while discarding the change. Before the fields became `omitempty` that
same configuration produced a loud 400, so the first commit on its own traded a
visible failure for a silent one on this one input shape.

`name` and `description` are `Required` with no length constraint, so `""` was
plannable. `validation.StringIsNotEmpty` makes that state unreachable, which is
the cheapest fix that does not widen `NullOps.PatchScopeType`'s contract beyond
what the endpoint accepts.

Migration: a configuration relying on `""` could never apply successfully — the
API rejected it before, and it would be silently ignored after — so no working
configuration changes behaviour.

## Tests

The regression test that shipped with the `omitempty` change marshalled a bare
`ScopeType` and asserted on the resulting map, so it verified `encoding/json`'s
handling of struct tags rather than the provider's behaviour: `ScopeTypeUpdate`
and `PatchScopeType` both stayed at 0.0% coverage, and a refactor of the update
path could re-break the reported bug with the test still green.

It now drives `ScopeTypeUpdate` and `ScopeTypeCreate` through a real diff
(`terraform.InstanceState` + `Diff` + `InternalMap`, so `HasChange` is genuinely
true for one field and false for the rest) against an `httptest` server that
captures the request body, following the idiom already established in
`resource_action_specification_test.go`. Assertions compare the whole decoded
payload, which also pins that the surviving field carries the new value.

- `TestScopeTypeUpdate_SendsOnlyChangedFields` — description-only, name-only and
  both. The description-only case never reaches `Update`'s `name` branch, which
  is the field the API actually refused, so the mirror of the original bug was
  unverified with that case alone.
- `TestScopeTypeUpdate_SurfacesAPIRefusal` — the 400's response body reaches the
  operator verbatim, making the message quoted above contract rather than
  unverified prose in a comment.
- `TestScopeType_RejectsEmptyRequiredStrings` — `""` for either field is refused
  by the schema.
- `TestScopeTypeCreate_SendsEveryField` — create still sends all seven fields.

Coverage ratchet raised 20.2 → 22.8 to match the lift.

## Verification

Reproduced with provider 0.0.100 against a live scope type. Red first, in both
directions: against the untagged struct the update test fails on the payload the
API refused (`name`, `status`, `type`, `provider_id` and `provider_type` as
empty strings) rather than on a map key count, and with the `ValidateFunc`
removed the empty-string test fails on both fields.

`go build ./...`, `go vet ./...` and `go test ./nullplatform/` pass;
`make coverage-new` reports 22.9% total with every added line covered. `docs/`
regenerated with `make update-docs`.
