### PR TITLE
fix(scope): make the deprecated NRN attributes optional

### DIFF
--- a/docs/resources/scope.md
+++ b/docs/resources/scope.md
@@ -74,11 +74,6 @@ output "scope" {
 
 - `capabilities_serverless_handler_name` (String) The function entrypoint in your code.
 - `capabilities_serverless_runtime_id` (String) Identifier of the function's runtime. See [Runtimes](https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html#lambda-CreateFunction-request-Runtime) for valid values.
-- `lambda_current_function_version` (String, Deprecated) The version number of the Lambda function used as the baseline for Null Platform to create new function versions (NRN key).
-- `lambda_function_main_alias` (String, Deprecated) The Lambda function main ALIAS name (NRN key).
-- `lambda_function_name` (String, Deprecated) The unique name of your Lambda function (NRN key).
-- `lambda_function_role` (String, Deprecated) The ARN of the function's execution role (NRN key).
-- `log_group_name` (String, Deprecated) The CloudWatch log group your Lambda function sends logs to (NRN key).
 - `null_application_id` (Number) The ID of the application that owns this scope.
 - `scope_name` (String) The scope name.
 
@@ -90,7 +85,12 @@ output "scope" {
 - `capabilities_serverless_timeout` (Number) Amount of time your Lambda Function has to run in seconds. Defaults to `10`.
 - `description` (String) Short description of the scope.
 - `dimensions` (Map of String) A key-value map with the runtime configuration dimensions that apply to this scope.
+- `lambda_current_function_version` (String, Deprecated) The version number of the Lambda function used as the baseline for Null Platform to create new function versions (NRN key).
+- `lambda_function_main_alias` (String, Deprecated) The Lambda function main ALIAS name (NRN key).
+- `lambda_function_name` (String, Deprecated) The unique name of your Lambda function (NRN key).
+- `lambda_function_role` (String, Deprecated) The ARN of the function's execution role (NRN key).
 - `lambda_function_warm_alias` (String, Deprecated) The Lambda function ALIAS name used to warmup the function (NRN key).
+- `log_group_name` (String, Deprecated) The CloudWatch log group your Lambda function sends logs to (NRN key).
 - `log_reader_role` (String, Deprecated) The ARN of the IAM Role to read CloudWatch logs (NRN key).
 - `s3_assets_bucket` (String, Deprecated) The AWS S3 bucket name where the assets are stored (NRN key).
 - `scope_asset_name` (String) The asset name for the scope.

--- a/internal/fakeplatform/scope.go
+++ b/internal/fakeplatform/scope.go
@@ -1,0 +1,45 @@
+package fakeplatform
+
+import "strings"
+
+type ScopeLog struct {
+	NrnPatches []Item
+}
+
+// RegisterScope mounts /scope and /nrn, with the NRN seeded at nrn holding awsNamespace
+// under namespaces.aws — the shape GetNRN reads. PATCH bodies land in the returned log.
+func RegisterScope(s *Server, nrn string, awsNamespace Item) *ScopeLog {
+	log := &ScopeLog{}
+
+	s.RegisterWith("scope", "scope", Options{NumericIDs: true}, Hooks{
+		OnCreate: func(_ *Server, item Item) *Refusal {
+			item["nrn"] = nrn
+			item["status"] = "active"
+			return nil
+		},
+	})
+
+	s.Register("nrn", "nrn", Hooks{
+		OnPatch: func(_ *Server, existing, patch Item) *Refusal {
+			log.NrnPatches = append(log.NrnPatches, patch)
+
+			namespaces, _ := existing["namespaces"].(Item)
+			aws, _ := namespaces["aws"].(Item)
+
+			for key, value := range patch {
+				if field, ok := strings.CutPrefix(key, "aws."); ok {
+					aws[field] = value
+				}
+			}
+
+			return nil
+		},
+	})
+
+	s.Seed("nrn", nrn, Item{
+		"nrn":        nrn,
+		"namespaces": Item{"aws": awsNamespace},
+	})
+
+	return log
+}

--- a/nullplatform/functional_scope_nrn_test.go
+++ b/nullplatform/functional_scope_nrn_test.go
@@ -1,0 +1,112 @@
+package nullplatform
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/nullplatform/terraform-provider-nullplatform/internal/fakeplatform"
+)
+
+const scopeNrn = "organization=1:account=2:namespace=3:application=4"
+
+func newScopeFake(t *testing.T) (*fakeplatform.Server, *fakeplatform.ScopeLog) {
+	t.Helper()
+	fake := fakeplatform.New()
+	log := fakeplatform.RegisterScope(fake, scopeNrn, fakeplatform.Item{
+		"s3_assets_bucket":             "seeded-bucket",
+		"scope_workflow_role":          "seeded-workflow-role",
+		"log_group_name":               "seeded-log-group",
+		"lambdaFunctionName":           "seeded-function",
+		"lambdaCurrentFunctionVersion": "7",
+		"lambdaFunctionRole":           "seeded-function-role",
+		"lambdaFunctionMainAlias":      "seeded-main-alias",
+		"log_reader_role":              "seeded-reader-role",
+		"lambdaFunctionWarmAlias":      "seeded-warm-alias",
+	})
+	t.Cleanup(fake.Close)
+	return fake, log
+}
+
+func scopeConfig(extra string) string {
+	return fmt.Sprintf(`
+provider "nullplatform" {}
+
+resource "nullplatform_scope" "s" {
+  scope_name          = "functional-scope"
+  null_application_id = 4
+
+  capabilities_serverless_runtime_id   = "nodejs20.x"
+  capabilities_serverless_handler_name = "index.handler"
+%s
+}
+`, extra)
+}
+
+// The NRN attributes are deprecated in favour of nullplatform_provider_config, so a scope
+// must be declarable without them — and the plan that follows must be clean even though
+// the NRN holds values for every one of them.
+func TestFunctionalScope_DeprecatedNrnAttributesAreOptional(t *testing.T) {
+	fake, _ := newScopeFake(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: functionalFactories(fake),
+		Steps: []resource.TestStep{
+			{
+				Config: scopeConfig(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("nullplatform_scope.s", "log_group_name", "seeded-log-group"),
+					resource.TestCheckResourceAttr("nullplatform_scope.s", "s3_assets_bucket", "seeded-bucket"),
+				),
+			},
+		},
+	})
+}
+
+// With nothing to patch, no PATCH is sent: the empty-payload guard has to actually guard.
+func TestFunctionalScope_NoNrnPatchWithoutDeprecatedAttributes(t *testing.T) {
+	fake, log := newScopeFake(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: functionalFactories(fake),
+		Steps: []resource.TestStep{
+			{
+				Config: scopeConfig(""),
+				Check: func(*terraform.State) error {
+					if len(log.NrnPatches) != 0 {
+						return fmt.Errorf("NRN patches sent = %v, want none", log.NrnPatches)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// A declared attribute still reaches the NRN: the deprecation does not disable the path.
+func TestFunctionalScope_DeclaredNrnAttributeIsPatched(t *testing.T) {
+	fake, log := newScopeFake(t)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: functionalFactories(fake),
+		Steps: []resource.TestStep{
+			{
+				Config: scopeConfig(`  log_group_name = "declared-log-group"`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("nullplatform_scope.s", "log_group_name", "declared-log-group"),
+					func(*terraform.State) error {
+						if len(log.NrnPatches) != 1 {
+							return fmt.Errorf("NRN patches sent = %d, want 1", len(log.NrnPatches))
+						}
+						if got := log.NrnPatches[0]["aws.log_group_name"]; got != "declared-log-group" {
+							return fmt.Errorf("patched log group = %v, want %q", got, "declared-log-group")
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}

--- a/nullplatform/resource_scope.go
+++ b/nullplatform/resource_scope.go
@@ -61,59 +61,64 @@ func resourceScope() *schema.Resource {
 			},
 			"s3_assets_bucket": {
 				Type:        schema.TypeString,
-				Default:     "",
 				Optional:    true,
+				Computed:    true,
 				Description: "The AWS S3 bucket name where the assets are stored (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"scope_workflow_role": {
 				Type:        schema.TypeString,
-				Default:     "",
 				Optional:    true,
+				Computed:    true,
 				Description: "The ARN of the IAM Role to deploy new versions of the Scope (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"log_group_name": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The CloudWatch log group your Lambda function sends logs to (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"lambda_function_name": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The unique name of your Lambda function (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"lambda_current_function_version": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The version number of the Lambda function used as the baseline for Null Platform to create new function versions (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"lambda_function_role": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The ARN of the function's execution role (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"lambda_function_main_alias": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The Lambda function main ALIAS name (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"log_reader_role": {
 				Type:        schema.TypeString,
-				Default:     "",
 				Optional:    true,
+				Computed:    true,
 				Description: "The ARN of the IAM Role to read CloudWatch logs (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
 			"lambda_function_warm_alias": {
 				Type:        schema.TypeString,
-				Default:     "",
 				Optional:    true,
+				Computed:    true,
 				Description: "The Lambda function ALIAS name used to warmup the function (NRN key).",
 				Deprecated:  "Configure NRN using the 'nullplatform_provider_config' resource instead.",
 			},
@@ -272,7 +277,7 @@ func patchNrnForScope(scopeNrn string, d *schema.ResourceData, m any) error {
 		AWSLambdaFunctionWarmAlias:      lambdaFunctionWarmAlias,
 	}
 
-	if !reflect.DeepEqual(nrnReq, PatchNRN{}) {
+	if *nrnReq != (PatchNRN{}) {
 		return nullOps.PatchNRN(scopeNrn, nrnReq)
 	}
 


### PR DESCRIPTION
Fixes #79.

## What

Five NRN attributes on `nullplatform_scope` were `Required` **and** `Deprecated` at the same time: the deprecation warning fired on every apply because there was no way not to set them, and a scope of any type had to invent Lambda values (the issue reports `log_group_name = "dummy_log_group_name"`).

All nine NRN-mirroring attributes become `Optional + Computed`.

## Why `Computed`, not just `Optional`

`ScopeRead` sets each attribute from the NRN. A plain `Optional` would then report the NRN's value against an absent config on every plan, forever. The four attributes that were already `Optional` carried `Default: ""` and had exactly that perpetual diff whenever the value came from `nullplatform_provider_config`.

Behavior change worth naming: with `Computed`, an attribute can no longer be cleared by setting it to `""` — the supported path for these values is `nullplatform_provider_config`.

`Required` → `Optional` never breaks an existing configuration.

## Also: the empty NRN patch

`patchNrnForScope` compared a `*PatchNRN` against a `PatchNRN` value — never equal, so every scope create and update sent a `PATCH /nrn` even with nothing to patch. With the attributes now optional that would have become an empty `PATCH {}` on every apply.

## Tests

Functional, against the fake platform seeded with an NRN holding all nine values:

- a scope declares none of them: the apply and the re-plan are both clean
- nothing declared: no `PATCH /nrn` is sent (reverting the guard fix makes this fail with `NRN patches sent = [map[]]`)
- one attribute declared: it still reaches the NRN

The fake gains a `scope`/`nrn` behavior module.

## Verification against the API

`terraform plan` on a real scope, with a config that declares none of the Lambda attributes: no error, and the nine attributes resolve as `(known after apply)`. Before this change the same config failed with five `Missing required argument` errors. No apply was run — creating a scope provisions infrastructure.

The read path could not be exercised the same way: importing a current scope fails to decode, because the API returns `"visibility": "public"` as a string while `Capability.Visibility` is a `map[string]string`. That is a separate bug, reported on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)