### PR TITLE
chore(coverage): raise the ratchet to 24.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,10 @@ cannot express the page.
   executed by some test, and the total never falls below
   `scripts/coverage_floor.txt` (a ratchet — lower it only when deleting covered
   code, in the same PR, saying so). `scripts/coverage_accepted.txt` entries are
-  claims of **impossibility**, not inconvenience.
+  claims of **impossibility**, not inconvenience. The floor is compared against
+  the **unrounded** total, which the report prints to one decimal: a 22.8949%
+  total reports `22.9%` and fails a 22.9 floor. Raise the floor to a value at or
+  below the true total — `covergate` nudges once coverage is a full point above.
 
 ## Layout
 

--- a/scripts/coverage_floor.txt
+++ b/scripts/coverage_floor.txt
@@ -1,4 +1,6 @@
-22.8
+24.4
 # The coverage ratchet: total statement coverage must not fall below this.
 # Raise it when a PR lifts the total; lower it ONLY when deleting covered
 # code, in the same PR, saying so in the commit message.
+# Compared against the unrounded total, which the report rounds to one decimal:
+# set this at or below the true total, never to the printed number.


### PR DESCRIPTION
`make coverage-new` on `main` asks for this:

```
note: coverage is 1.6 points above the floor — consider raising
scripts/coverage_floor.txt to 24.4 in this PR
```

The `api_key` tests that landed in #158 lifted total statement coverage from
22.9% to 24.4%, which is `covergate`'s own threshold (`totalPct >= floor+1.0`)
for asking that the ratchet follow. Left at 22.8, the gate would let a point and
a half of coverage regress without failing.

## The caveat this also documents

24.4 is satisfiable because the true total is **24.4125%** — it rounds down.
That is not always the case: the floor is compared against the unrounded total
while the report prints one decimal, so a floor set to the printed number is
refused whenever the total rounds up. A 22.8949% total reports `22.9%` and then
fails a 22.9 floor with a message that reads like a bug in the gate:

```
total coverage 22.9% fell below the floor 22.9% (scripts/coverage_floor.txt)
```

`coverage_floor.txt`'s own instruction to "raise it when a PR lifts the total"
reads as an invitation to do exactly that, so the caveat now sits both in
`CLAUDE.md` next to the gate's description and beside the number itself, where
someone is about to edit it.

## Verification

`make coverage-new` passes with the new floor: total 24.4%, no added lines under
`nullplatform/` in this PR. No covered code was deleted — the floor only moves
up.

Worth considering separately (not in this PR): `covergate` derives its suggested
value with `%.1f` of the total, so it can suggest a floor that its own
comparison then refuses. Truncating instead of rounding would remove the trap
rather than document it.
