### PR TITLE
ci(docs): check out the head repo so fork PRs don't fail at checkout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
## The bug

The `docs` workflow fails at its very first step for **any** pull request coming from a fork. Example: [run 33688919471](https://github.com/nullplatform/terraform-provider-nullplatform/actions/runs/33688919471) on #162.

```
git -c protocol.version=2 fetch --no-tags --prune --depth=1 origin \
  +refs/heads/fix/namespace-rename-in-place*:refs/remotes/origin/fix/namespace-rename-in-place*
The process '/usr/bin/git' failed with exit code 1   (3 retries, then the job dies)
```

`Checkout PR branch` passed `ref: ${{ github.head_ref }}` without a matching `repository`, so `actions/checkout` fell back to its default (`github.repository`) and tried to fetch the head branch name from *this* repository. `github.head_ref` is only a branch name — it carries no repo — and for a fork PR that branch does not exist here, so the fetch exits 1 before any docs are generated.

Nothing about the affected PRs is wrong; the job never gets far enough to look at their code. This has been latent since the workflow was added (1976dd7) because only internal branches (dependabot, `nullplatform/*`) had exercised it, and for those the branch does exist in `origin`.

## The fix

Pair `ref` with the head repository:

```yaml
repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
ref: ${{ github.head_ref || github.ref }}
```

The `||` fallbacks keep `workflow_dispatch` working, where both contexts are empty — passing an empty string overrides the action's default rather than falling back to it.

Dropping `ref` entirely would also fetch successfully (checkout's `pull_request` default is the merge ref `refs/pull/N/merge`, which exists in the base repo even for forks), but it leaves a detached HEAD on a merge commit, which would break the `git push origin HEAD:$BRANCH` in `Commit regenerated docs`. Hence pinning both inputs.

## Why this is safe

The workflow already handled forks downstream — this change just lets them reach that logic:

- `Commit regenerated docs` stays gated on `head.repo.full_name == github.repository`, so it never tries to push to a fork.
- Fork PRs now reach `Fail if out of date (fork PR or manual run)`, which is exactly what the workflow's header comment describes as the intended behaviour.

On the security side:

- **No `allow-unsafe-pr-checkout: true` needed.** That guard in checkout v7 only applies to `pull_request_target` and `workflow_run`; this workflow triggers on `pull_request`.
- **No "pwn request" exposure.** On a fork PR GitHub degrades `GITHUB_TOKEN` to read-only regardless of the `permissions: contents: write` block, so running `go generate ./...` over fork code does not hand it a write-scoped token, secrets, or the default-branch cache scope.

## Verification

- `docs.yml` parses and the step resolves as expected (`python3 -c "yaml.safe_load(...)"`).
- Not verified end-to-end on a fork PR yet: this PR is from an internal branch, so its own `docs` run exercises the same-repo path only. Re-running the check on #162 after this merges is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)