### PR TITLE
fix(artifact): fall back to a visible artifact whose revision matches when the owned one has none

### DIFF
--- a/nullplatform/data_source_platform_artifact.go
+++ b/nullplatform/data_source_platform_artifact.go
@@ -130,52 +130,66 @@ func dataSourcePlatformArtifactRead(_ context.Context, d *schema.ResourceData, m
 		}
 	}
 	// The listing is visibility-scoped, so an artifact owned at the nrn can
-	// coexist with a shared/global one of the same identity. The owned one
-	// wins: it's what this configuration (or its owner) registered, and it
-	// keeps configs written before globals existed resolving unchanged.
-	if len(matched) > 1 {
-		var owned []*PlatformArtifact
-		for _, artifact := range matched {
-			if artifact.Nrn == nrn {
-				owned = append(owned, artifact)
-			}
-		}
-		if len(owned) == 1 {
-			matched = owned
-		}
-	}
+	// coexist with a shared/global one of the same identity. The owned one is
+	// preferred: it's what this configuration (or its owner) registered, and it
+	// keeps configs written before globals existed resolving unchanged. But
+	// preference is not exclusion: artifacts are immutable and cannot be
+	// deleted, so an owned artifact registered by digest before the upstream
+	// one existed would otherwise shadow it forever and make a lookup by tag
+	// (which only the upstream revisions carry) impossible from that nrn. So
+	// candidates are ordered owned-first and the first one holding a revision
+	// that matches every requested field wins.
 	if len(matched) == 0 {
 		return diag.FromErr(fmt.Errorf("no %s artifact visible at %s matches meta %v", artifactType, nrn, wantedMeta))
 	}
-	if len(matched) > 1 {
-		return diag.FromErr(fmt.Errorf("meta %v matches %d %s artifacts visible at %s; add identity fields to disambiguate", wantedMeta, len(matched), artifactType, nrn))
-	}
-	artifact := matched[0]
-
-	revisions, err := nullOps.ListPlatformArtifactRevisions(artifact.ResourceID)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// Revision match: NEWEST revision whose meta carries every requested
-	// field. Sorted here rather than trusting API order — the newest-wins
-	// rule is what gives tag lookups their drift semantics: re-registering a
-	// tag against a new digest mints a newer revision, and the next plan
-	// resolves it (and its digest) instead of the stale one. When only
-	// identity fields were requested every revision matches, so this
-	// resolves to the latest one.
-	sort.SliceStable(revisions, func(i, j int) bool {
-		return revisions[i].CreatedAt > revisions[j].CreatedAt
+	sort.SliceStable(matched, func(i, j int) bool {
+		return matched[i].Nrn == nrn && matched[j].Nrn != nrn
 	})
+	if len(matched) > 1 {
+		owned := 0
+		for _, artifact := range matched {
+			if artifact.Nrn == nrn {
+				owned++
+			}
+		}
+		if owned > 1 {
+			return diag.FromErr(fmt.Errorf("meta %v matches %d %s artifacts owned at %s; add identity fields to disambiguate", wantedMeta, owned, artifactType, nrn))
+		}
+	}
+
+	var artifact *PlatformArtifact
 	var revision *PlatformArtifactRevision
-	for _, candidate := range revisions {
-		if metaMatches(wantedMeta, candidate.Meta) {
-			revision = candidate
+	for _, candidate := range matched {
+		revisions, err := nullOps.ListPlatformArtifactRevisions(candidate.ResourceID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// Revision match: NEWEST revision whose meta carries every requested
+		// field. Sorted here rather than trusting API order — the newest-wins
+		// rule is what gives tag lookups their drift semantics: re-registering a
+		// tag against a new digest mints a newer revision, and the next plan
+		// resolves it (and its digest) instead of the stale one. When only
+		// identity fields were requested every revision matches, so this
+		// resolves to the latest one.
+		sort.SliceStable(revisions, func(i, j int) bool {
+			return revisions[i].CreatedAt > revisions[j].CreatedAt
+		})
+		for _, r := range revisions {
+			if metaMatches(wantedMeta, r.Meta) {
+				artifact, revision = candidate, r
+				break
+			}
+		}
+		if revision != nil {
 			break
 		}
 	}
 	if revision == nil {
-		return diag.FromErr(fmt.Errorf("artifact %s has no revision matching meta %v", artifact.ResourceID, wantedMeta))
+		ids := make([]string, 0, len(matched))
+		for _, candidate := range matched {
+			ids = append(ids, candidate.ResourceID)
+		}
+		return diag.FromErr(fmt.Errorf("no revision of %s artifact(s) %v visible at %s matches meta %v", artifactType, ids, nrn, wantedMeta))
 	}
 
 	revisionMetaJSON, err := json.Marshal(revision.Meta)

--- a/nullplatform/data_source_platform_artifact_test.go
+++ b/nullplatform/data_source_platform_artifact_test.go
@@ -218,6 +218,83 @@ func TestDataSourcePlatformArtifactRead_FallsBackToGlobalWhenOwnedHasNoMatchingR
 	}
 }
 
+// When no candidate — owned or global — holds a revision matching the requested
+// fields, the error names every artifact that was examined so the reader can
+// tell which registrations were considered and what they lack.
+func TestDataSourcePlatformArtifactRead_NoCandidateRevisionMatchesErrors(t *testing.T) {
+	var gotQuery string
+	server := artifactServer(t,
+		[]*PlatformArtifact{
+			{
+				ResourceID:   "art-owned",
+				Type:         "oci_image",
+				Nrn:          "organization=4",
+				IdentityMeta: map[string]interface{}{"registry": "r.io", "repository": "org/app"},
+			},
+			{
+				ResourceID:   "art-global",
+				Type:         "oci_image",
+				Nrn:          "organization=1",
+				IdentityMeta: map[string]interface{}{"registry": "r.io", "repository": "org/app"},
+				VisibleTo:    []string{"organization=*"},
+			},
+		},
+		map[string][]*PlatformArtifactRevision{
+			"art-owned":  {{ResourceRevisionID: "rev-owned", Meta: map[string]interface{}{"registry": "r.io", "repository": "org/app", "digest": "sha256:mine"}, CreatedAt: "2026-09-01T00:00:00Z"}},
+			"art-global": {{ResourceRevisionID: "rev-global", Meta: map[string]interface{}{"registry": "r.io", "repository": "org/app", "tag": "v1.0.0", "digest": "sha256:theirs"}, CreatedAt: "2026-09-02T00:00:00Z"}},
+		},
+		&gotQuery,
+	)
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, dataSourcePlatformArtifact().Schema, map[string]interface{}{
+		"nrn":  "organization=4",
+		"type": "oci_image",
+		"meta": `{"registry":"r.io","repository":"org/app","tag":"v9.9.9"}`,
+	})
+
+	diags := dataSourcePlatformArtifactRead(context.Background(), d, newTestClient(server))
+	if !diags.HasError() {
+		t.Fatal("expected an error when no candidate has a revision matching the tag")
+	}
+	msg := diags[0].Summary
+	for _, want := range []string{"art-owned", "art-global", "v9.9.9"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q should mention %q", msg, want)
+		}
+	}
+}
+
+// A failure listing a candidate's revisions surfaces as the read's error
+// instead of being skipped as "no match".
+func TestDataSourcePlatformArtifactRead_RevisionListingErrorPropagates(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/artifacts" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(platformArtifactListResponse{Results: []*PlatformArtifact{{
+				ResourceID:   "art-owned",
+				Type:         "oci_image",
+				Nrn:          "organization=4",
+				IdentityMeta: map[string]interface{}{"registry": "r.io", "repository": "org/app"},
+			}}})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, dataSourcePlatformArtifact().Schema, map[string]interface{}{
+		"nrn":  "organization=4",
+		"type": "oci_image",
+		"meta": `{"registry":"r.io","repository":"org/app"}`,
+	})
+
+	diags := dataSourcePlatformArtifactRead(context.Background(), d, newTestClient(server))
+	if !diags.HasError() {
+		t.Fatal("expected the revision listing failure to be returned as an error")
+	}
+}
+
 // No visible artifact matching the identity meta is an explicit error, not an
 // empty result.
 func TestDataSourcePlatformArtifactRead_NoMatchErrors(t *testing.T) {

--- a/nullplatform/data_source_platform_artifact_test.go
+++ b/nullplatform/data_source_platform_artifact_test.go
@@ -161,6 +161,63 @@ func TestDataSourcePlatformArtifactRead_OwnedBeatsGlobalOnAmbiguity(t *testing.T
 	}
 }
 
+// An owned artifact registered by digest before the upstream one existed must
+// not shadow the global one forever: when the owned artifact has no revision
+// matching the requested fields (here a tag only the global carries), the
+// lookup falls back to the next candidate instead of failing. Artifacts are
+// immutable and cannot be deleted, so without this a lookup by tag would be
+// impossible from any nrn that ever registered its own copy.
+func TestDataSourcePlatformArtifactRead_FallsBackToGlobalWhenOwnedHasNoMatchingRevision(t *testing.T) {
+	var gotQuery string
+	server := artifactServer(t,
+		[]*PlatformArtifact{
+			{
+				ResourceID:   "art-owned",
+				Type:         "oci_image",
+				Nrn:          "organization=4",
+				IdentityMeta: map[string]interface{}{"registry": "r.io", "repository": "org/app"},
+			},
+			{
+				ResourceID:   "art-global",
+				Type:         "oci_image",
+				Nrn:          "organization=1",
+				IdentityMeta: map[string]interface{}{"registry": "r.io", "repository": "org/app"},
+				VisibleTo:    []string{"organization=*"},
+			},
+		},
+		map[string][]*PlatformArtifactRevision{
+			"art-owned": {
+				{ResourceRevisionID: "rev-owned", Meta: map[string]interface{}{"registry": "r.io", "repository": "org/app", "digest": "sha256:mine"}, CreatedAt: "2026-09-01T00:00:00Z"},
+			},
+			"art-global": {
+				{ResourceRevisionID: "rev-global-tagged", Meta: map[string]interface{}{"registry": "r.io", "repository": "org/app", "tag": "v1.0.0", "digest": "sha256:theirs"}, CreatedAt: "2026-09-02T00:00:00Z"},
+			},
+		},
+		&gotQuery,
+	)
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, dataSourcePlatformArtifact().Schema, map[string]interface{}{
+		"nrn":  "organization=4",
+		"type": "oci_image",
+		"meta": `{"registry":"r.io","repository":"org/app","tag":"v1.0.0"}`,
+	})
+
+	diags := dataSourcePlatformArtifactRead(context.Background(), d, newTestClient(server))
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if got := d.Get("artifact_id").(string); got != "art-global" {
+		t.Errorf("artifact_id = %q, want art-global (owned has no revision with the tag)", got)
+	}
+	if got := d.Get("revision_id").(string); got != "rev-global-tagged" {
+		t.Errorf("revision_id = %q, want rev-global-tagged", got)
+	}
+	if got := d.Get("digest").(string); got != "sha256:theirs" {
+		t.Errorf("digest = %q, want sha256:theirs", got)
+	}
+}
+
 // No visible artifact matching the identity meta is an explicit error, not an
 // empty result.
 func TestDataSourcePlatformArtifactRead_NoMatchErrors(t *testing.T) {

--- a/scripts/coverage_accepted.txt
+++ b/scripts/coverage_accepted.txt
@@ -33,4 +33,4 @@ nullplatform/resource_service_specification.go:326-327  # d.Set(selectors, list)
 # `return nil, nil` after the assert is unreachable through that contract.
 nullplatform/resource_service.go:632  # raw.(*Service) fallthrough
 nullplatform/resource_link.go:389     # raw.(*Link) fallthrough
-nullplatform/data_source_platform_artifact.go:198-199  # d.Set(digest, string) arm
+nullplatform/data_source_platform_artifact.go:212-213  # d.Set(digest, string) arm


### PR DESCRIPTION
## Qué pasa hoy

`data "nullplatform_artifact"` lista los artifacts visibles al `nrn` y, cuando más de uno matchea la identidad pedida (por ejemplo `registry` + `repository`), se queda con el que está **registrado en ese mismo nrn**, sin mirar si tiene alguna revisión que matchee el resto de los campos. Después busca la revisión y, si no hay ninguna, falla:

```
Error: artifact 5cc34652-… has no revision matching meta map[registry:public.ecr.aws repository:nullplatform/scopes/lambda tag:v0.5.0]
```

El caso concreto, de una instalación real:

1. Antes de que nullplatform publicara sus artifacts globales (`organization=*`), la instalación registró los suyos, por digest, para poder empaquetar sus scopes.
2. Ahora existen los globales con `tag` y la instalación quiere pasar a `lookup = true` por tag, que es lo que 0.0.102 habilita.
3. El lookup encuentra dos artifacts con la misma identidad, elige el propio, el propio no tiene ninguna revisión con `tag`, y falla. El global, que sí la tiene, nunca se considera.
4. No hay salida: los artifacts son inmutables y `nullplatform_artifact` no borra nada en el destroy (la API no expone delete). El propio va a existir para siempre y va a tapar al global desde ese nrn.

Cualquier instalación que haya registrado artifacts propios antes de que existieran los globales, o sea todas las que migraron temprano, queda sin poder usar tags.

## Qué cambia

Se mantiene la preferencia por el artifact propio, que es lo que hace que las configuraciones anteriores sigan resolviendo igual. Pero la preferencia deja de ser exclusión: los candidatos se ordenan propio primero y gana **el primero que tenga una revisión que matchee todos los campos pedidos**. Si el propio tiene la revisión, se comporta exactamente como hoy. Si no la tiene, cae al global en vez de fallar.

Detalles:

- Si hay más de un artifact **propio** con la misma identidad sigue siendo un error de ambigüedad, como antes.
- El error final cuando ningún candidato tiene una revisión que matchee lista todos los ids evaluados, para que se entienda qué se miró.
- Test nuevo `TestDataSourcePlatformArtifactRead_FallsBackToGlobalWhenOwnedHasNoMatchingRevision`: propio con solo digest, global con tag, lookup por tag resuelve el global y su digest. Los tests existentes, incluido `OwnedBeatsGlobalOnAmbiguity`, siguen pasando sin cambios.
